### PR TITLE
Phase 4: Edit and delete visit functionality

### DIFF
--- a/SPECIFICATIONS/visit_logging.md
+++ b/SPECIFICATIONS/visit_logging.md
@@ -24,12 +24,13 @@
 - Security hardening (XSS prevention, rating validation, timezone fixes)
 - Toast notifications and error handling
 
-**Phase 4: Edit/Delete Visits** 🔄 NEXT
-- Edit existing visits
-- Delete visits with confirmation
-- Fix placeholder dates
+**Phase 4: Edit/Delete Visits** ✅ COMPLETE (PR #5, 2026-03-02)
+- Edit existing visits with updateVisit()
+- Delete visits with confirmation dialog
+- Fix placeholder dates (clears migrated flag)
+- 13 new tests, 100 total passing
 
-**Phase 5: Verification & Documentation** ⏳ UPCOMING
+**Phase 5: Verification & Documentation** 🔄 NEXT
 - End-to-end testing
 - Performance verification
 - Security verification
@@ -624,41 +625,58 @@ async function checkRateLimit(userId: string, operation: string): Promise<boolea
 
 ---
 
-### Phase 4: Edit/Delete Visits
+### Phase 4: Edit/Delete Visits ✅ COMPLETE
 **Branch:** `feature/edit-delete-visits`
+**PR:** #5
 **Goal:** Allow users to edit or delete existing visits
 
-**Tasks:**
-1. Add `visitService.ts` edit/delete operations:
-   - `updateVisit()` with validation
-   - `deleteVisit()`
-2. Add edit button to `VisitHistory.tsx` component
-   - On click, opens `VisitModal` with `visitToEdit` prop populated
-   - Modal pre-fills form with existing visit data
-3. Update `VisitModal.tsx`:
-   - Detect edit mode (when `visitToEdit` prop is present)
-   - Use `visitService.updateVisit()` instead of `addVisit()` when editing
-   - Update modal title: "Add Visit" vs "Edit Visit"
-   - When user edits date on migrated visit, set `is_migrated_placeholder = FALSE`
-4. Add delete button to visit entries
-   - Shows confirmation dialog before deleting
-   - Calls `visitService.deleteVisit()`
-5. Handle optimistic updates for better UX
-6. Database trigger auto-updates cached rating after edit/delete (no manual refresh needed)
+**Implementation:**
+1. ✅ Added `visitService.ts` edit/delete operations:
+   - `updateVisit()` with full validation (XSS, rating, date, length)
+   - `deleteVisit()` with authentication check
+   - Clears `is_migrated_placeholder` flag when date changed
+   - Handles duplicate date conflicts
+2. ✅ Added edit/delete buttons to `VisitHistory.tsx`:
+   - Edit button opens `VisitModal` pre-filled with visit data
+   - Delete button opens AlertDialog confirmation
+   - Action buttons conditionally rendered based on callbacks
+3. ✅ Updated `VisitModal.tsx` for edit mode:
+   - Detects edit mode via `visitToEdit` prop
+   - Calls `updateVisit()` instead of `addVisit()` when editing
+   - Modal title changes: "Add Visit" vs "Edit Visit"
+   - Submit button changes: "Add Visit" vs "Update Visit"
+4. ✅ Delete confirmation dialog:
+   - AlertDialog from shadcn/ui
+   - Clear warning about irreversible action
+   - Destructive styling on confirm button
+5. ✅ `RestaurantDetails.tsx` integration:
+   - Handlers for edit and delete with query invalidation
+   - Toast notifications for user feedback
+   - State management for visitToEdit and visitToDelete
+6. ✅ Database trigger auto-updates cached rating after edit/delete
 
-**Key user flow:** Users can fix placeholder "Before 2026" dates by:
-1. Click edit on migrated visit
-2. Change date to actual date they remember
-3. `is_migrated_placeholder` automatically set to FALSE
-4. Date now displays as formatted date instead of "Before 2026"
+**Key user flow: Fixing placeholder dates**
+1. Click edit on migrated visit (shows "Before 2026")
+2. Change date to actual date remembered
+3. `is_migrated_placeholder` automatically set to FALSE on save
+4. Date now displays normally (e.g., "Feb 15, 2026")
 
 **Testing:**
-- Test edit flow (including placeholder date fixes)
-- Test `is_migrated_placeholder` cleared when date edited
-- Test delete flow with confirmation
-- Test delete edge cases (only visit, latest visit, middle visit)
-- Test error handling
-- Test trigger updates cached rating correctly
+- ✅ 13 new service tests for updateVisit and deleteVisit
+- ✅ Component test for edit mode submission
+- ✅ All validation tests (XSS, rating, date, length)
+- ✅ Duplicate date detection test
+- ✅ Migrated placeholder flag clearing test
+- ✅ 100 tests passing across entire project
+- ⏳ Manual testing pending
+- ⏳ End-to-end testing (Phase 5)
+
+**Result:**
+- Users can now edit and delete visit history entries
+- Placeholder dates from migration can be corrected
+- All security features maintained (XSS prevention, validation)
+- Database trigger keeps cached ratings synchronized
+- Ready for Phase 5: verification and documentation
 
 **Acceptance Criteria:**
 - ✅ Edit button opens modal pre-populated with visit data

--- a/src/components/VisitHistory.tsx
+++ b/src/components/VisitHistory.tsx
@@ -1,19 +1,22 @@
 // ABOUT: Component to display visit history for a restaurant
-// ABOUT: Shows list of visits with dates, ratings, and notes (read-only)
+// ABOUT: Shows list of visits with dates, ratings, notes, and edit/delete actions
 
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Calendar, User, Edit2, Trash2 } from 'lucide-react';
 import { RestaurantVisit } from '@/types/place';
 import { APPRECIATION_LEVELS } from '@/types/place';
 import { visitService } from '@/services/visits';
 
 interface VisitHistoryProps {
   restaurantId: string;
+  onEdit?: (visit: RestaurantVisit) => void;
+  onDelete?: (visit: RestaurantVisit) => void;
 }
 
-export const VisitHistory = ({ restaurantId }: VisitHistoryProps) => {
+export const VisitHistory = ({ restaurantId, onEdit, onDelete }: VisitHistoryProps) => {
   const [visits, setVisits] = useState<RestaurantVisit[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -106,12 +109,42 @@ export const VisitHistory = ({ restaurantId }: VisitHistoryProps) => {
               key={visit.id}
               className="pb-4 border-b last:border-b-0 last:pb-0"
             >
-              {/* Visit Date */}
-              <div className="flex items-center gap-2 mb-2">
-                <Calendar className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm font-medium">
-                  {formatVisitDate(visit)}
-                </span>
+              {/* Visit Date and Actions */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm font-medium">
+                    {formatVisitDate(visit)}
+                  </span>
+                </div>
+
+                {/* Edit/Delete Actions */}
+                {(onEdit || onDelete) && (
+                  <div className="flex items-center gap-1">
+                    {onEdit && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onEdit(visit)}
+                        className="h-7 px-2 text-muted-foreground hover:text-foreground"
+                      >
+                        <Edit2 className="w-3 h-3" />
+                        <span className="sr-only">Edit visit</span>
+                      </Button>
+                    )}
+                    {onDelete && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onDelete(visit)}
+                        className="h-7 px-2 text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="w-3 h-3" />
+                        <span className="sr-only">Delete visit</span>
+                      </Button>
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* Rating Badge */}

--- a/src/components/VisitModal.tsx
+++ b/src/components/VisitModal.tsx
@@ -1,4 +1,4 @@
-// ABOUT: Modal component for adding (and future editing) restaurant visits
+// ABOUT: Modal component for adding and editing restaurant visits
 // ABOUT: Handles date selection, rating, and notes for visit logging
 
 import { useState, useEffect } from 'react';
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { PersonalAppreciation, APPRECIATION_LEVELS, RestaurantVisit } from '@/types/place';
-import { visitService, CreateVisitInput } from '@/services/visits';
+import { visitService, CreateVisitInput, UpdateVisitInput } from '@/services/visits';
 
 interface VisitModalProps {
   isOpen: boolean;
@@ -79,20 +79,24 @@ export const VisitModal = ({
     setIsSubmitting(true);
 
     try {
-      const visitData: CreateVisitInput = {
-        restaurant_id: restaurantId,
-        visit_date: visitDate,
-        rating: rating,
-        experience_notes: experienceNotes.trim() || undefined,
-        company_notes: companyNotes.trim() || undefined,
-      };
-
-      if (isEditMode) {
+      if (isEditMode && visitToEdit) {
         // Phase 4: Update existing visit
-        // await visitService.updateVisit(visitToEdit.id, visitData);
-        console.log('Edit mode - Phase 4 implementation');
+        const updateData: UpdateVisitInput = {
+          visit_date: visitDate,
+          rating: rating,
+          experience_notes: experienceNotes.trim() || undefined,
+          company_notes: companyNotes.trim() || undefined,
+        };
+        await visitService.updateVisit(visitToEdit.id, updateData);
       } else {
         // Phase 3: Create new visit
+        const visitData: CreateVisitInput = {
+          restaurant_id: restaurantId,
+          visit_date: visitDate,
+          rating: rating,
+          experience_notes: experienceNotes.trim() || undefined,
+          company_notes: companyNotes.trim() || undefined,
+        };
         await visitService.addVisit(visitData);
       }
 

--- a/src/pages/RestaurantDetails.tsx
+++ b/src/pages/RestaurantDetails.tsx
@@ -5,14 +5,25 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { MapPin, Star, Globe, ArrowLeft, Phone, Clock, Heart, Plus, Shield } from "lucide-react";
 import { InteractiveMap } from "@/components/InteractiveMap";
 import { restaurantService } from "@/services/restaurants";
-import { Restaurant, RestaurantAddress, APPRECIATION_LEVELS, PersonalAppreciation, RestaurantStatus } from "@/types/place";
+import { Restaurant, RestaurantAddress, RestaurantVisit, APPRECIATION_LEVELS, PersonalAppreciation, RestaurantStatus } from "@/types/place";
 import { useAuth } from "@/contexts/AuthContext";
 import { AppreciationPicker } from "@/components/AppreciationPicker";
 import { VisitHistory } from "@/components/VisitHistory";
 import { VisitModal } from "@/components/VisitModal";
+import { visitService } from "@/services/visits";
 import { useToast } from "@/hooks/use-toast";
 
 const RestaurantDetails = () => {
@@ -24,6 +35,8 @@ const RestaurantDetails = () => {
   const [showAllDishes, setShowAllDishes] = useState(false);
   const [showAppreciationPicker, setShowAppreciationPicker] = useState(false);
   const [showVisitModal, setShowVisitModal] = useState(false);
+  const [visitToEdit, setVisitToEdit] = useState<RestaurantVisit | undefined>(undefined);
+  const [visitToDelete, setVisitToDelete] = useState<RestaurantVisit | null>(null);
   const [pendingStatus, setPendingStatus] = useState<RestaurantStatus | null>(null);
 
   // Fetch restaurant with all location details
@@ -188,7 +201,46 @@ const RestaurantDetails = () => {
   // Handle visit modal close
   const handleVisitModalClose = () => {
     setShowVisitModal(false);
+    setVisitToEdit(undefined);
     setPendingStatus(null);
+  };
+
+  // Handle edit visit
+  const handleEditVisit = (visit: RestaurantVisit) => {
+    setVisitToEdit(visit);
+    setShowVisitModal(true);
+  };
+
+  // Handle delete visit
+  const handleDeleteVisit = (visit: RestaurantVisit) => {
+    setVisitToDelete(visit);
+  };
+
+  // Confirm delete visit
+  const confirmDeleteVisit = async () => {
+    if (!visitToDelete) return;
+
+    try {
+      await visitService.deleteVisit(visitToDelete.id);
+
+      // Invalidate queries to refresh data
+      queryClient.invalidateQueries({ queryKey: ["restaurant", id] });
+      queryClient.invalidateQueries({ queryKey: ["restaurants"] });
+
+      toast({
+        title: "Visit deleted",
+        description: "Visit has been removed from your history.",
+      });
+    } catch (err) {
+      console.error('Error deleting visit:', err);
+      toast({
+        title: "Error",
+        description: err instanceof Error ? err.message : "Failed to delete visit",
+        variant: "destructive",
+      });
+    } finally {
+      setVisitToDelete(null);
+    }
   };
 
   // Keep old AppreciationPicker handlers for backward compatibility (may remove in future)
@@ -523,7 +575,11 @@ const RestaurantDetails = () => {
                   {/* Row 1: Visit History (logged in only) - spans 2 rows */}
                   {user && (
                     <div className="lg:row-span-2">
-                      <VisitHistory restaurantId={restaurant.id} />
+                      <VisitHistory
+                        restaurantId={restaurant.id}
+                        onEdit={handleEditVisit}
+                        onDelete={handleDeleteVisit}
+                      />
                     </div>
                   )}
 
@@ -688,7 +744,11 @@ const RestaurantDetails = () => {
                   {/* Row 1: Visit History (logged in only) - spans 2 rows */}
                   {user && (
                     <div className="lg:row-span-2">
-                      <VisitHistory restaurantId={restaurant.id} />
+                      <VisitHistory
+                        restaurantId={restaurant.id}
+                        onEdit={handleEditVisit}
+                        onDelete={handleDeleteVisit}
+                      />
                     </div>
                   )}
 
@@ -855,8 +915,30 @@ const RestaurantDetails = () => {
           onSuccess={handleVisitSuccess}
           restaurantId={restaurant.id}
           restaurantName={restaurant.name}
+          visitToEdit={visitToEdit}
         />
       )}
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={!!visitToDelete} onOpenChange={(open) => !open && setVisitToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Visit</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this visit? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDeleteVisit}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/pages/RestaurantDetails.tsx
+++ b/src/pages/RestaurantDetails.tsx
@@ -224,7 +224,10 @@ const RestaurantDetails = () => {
       await visitService.deleteVisit(visitToDelete.id);
 
       // Invalidate queries to refresh data
+      // - Restaurant detail: refreshes visit history display
       queryClient.invalidateQueries({ queryKey: ["restaurant", id] });
+      // - Restaurant list: cached appreciation is recalculated by database trigger
+      //   (if last visit was deleted, appreciation returns to 'unknown')
       queryClient.invalidateQueries({ queryKey: ["restaurants"] });
 
       toast({

--- a/src/services/visits.ts
+++ b/src/services/visits.ts
@@ -17,6 +17,7 @@ interface CreateVisitInput {
 
 /**
  * Input data for updating an existing visit
+ * Note: restaurant_id is intentionally excluded - visits cannot be reassigned to different restaurants
  */
 interface UpdateVisitInput {
   visit_date: string; // ISO date string (YYYY-MM-DD)
@@ -25,53 +26,77 @@ interface UpdateVisitInput {
   company_notes?: string;
 }
 
+// ============================================================================
+// Shared Validation Helpers
+// ============================================================================
+
 /**
- * Validates and sanitizes visit input data
- * @param input - Raw visit input data
- * @returns Sanitized input data
- * @throws Error if validation fails
+ * Strips HTML-like characters and trims whitespace from text
+ * @param text - Input text to sanitize
+ * @returns Sanitized text or undefined if empty
+ * @throws Error if HTML-like characters are found
  */
-const validateVisitInput = (input: CreateVisitInput): CreateVisitInput => {
-  // Validate rating - prevent 'unknown' and invalid values
-  const validRatings: PersonalAppreciation[] = ['avoid', 'fine', 'good', 'great'];
-  if (!validRatings.includes(input.rating)) {
-    throw new Error('Rating must be a valid appreciation level (avoid, fine, good, or great)');
+const stripHtml = (text?: string): string | undefined => {
+  if (!text) return undefined;
+
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+
+  // Reject any HTML-like characters to prevent XSS attacks
+  // This prevents: <script>, encoded HTML entities (&lt;), event handlers, etc.
+  if (/<|>|&/.test(trimmed)) {
+    throw new Error('HTML and special characters are not allowed in notes');
   }
 
+  return trimmed;
+};
+
+/**
+ * Validates that rating is a valid appreciation level (not 'unknown')
+ * @param rating - Rating to validate
+ * @throws Error if rating is invalid
+ */
+const validateRating = (rating: PersonalAppreciation): void => {
+  const validRatings: PersonalAppreciation[] = ['avoid', 'fine', 'good', 'great'];
+  if (!validRatings.includes(rating)) {
+    throw new Error('Rating must be a valid appreciation level (avoid, fine, good, or great)');
+  }
+};
+
+/**
+ * Validates date format and range
+ * @param visitDate - Date string to validate (YYYY-MM-DD)
+ * @throws Error if date format is invalid or out of range
+ */
+const validateDate = (visitDate: string): void => {
   // Validate date format (YYYY-MM-DD)
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.visit_date)) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(visitDate)) {
     throw new Error('Invalid date format. Expected YYYY-MM-DD');
   }
 
   // Validate date range (not in future, not before 1900)
   // Use string comparison to avoid timezone issues with YYYY-MM-DD format
-  const visitDateStr = input.visit_date;
   const todayStr = new Date().toISOString().split('T')[0]; // YYYY-MM-DD in UTC
   const minDateStr = '1900-01-01';
 
-  if (visitDateStr < minDateStr || visitDateStr > todayStr) {
+  if (visitDate < minDateStr || visitDate > todayStr) {
     throw new Error('Visit date must be between 1900-01-01 and today');
   }
+};
 
-  // Sanitize text fields: reject HTML-like characters, trim whitespace
-  // Using strict rejection approach to prevent XSS (encoded HTML, event handlers, etc.)
-  const stripHtml = (text?: string): string | undefined => {
-    if (!text) return undefined;
-
-    const trimmed = text.trim();
-    if (!trimmed) return undefined;
-
-    // Reject any HTML-like characters to prevent XSS attacks
-    // This prevents: <script>, encoded HTML entities (&lt;), event handlers, etc.
-    if (/<|>|&/.test(trimmed)) {
-      throw new Error('HTML and special characters are not allowed in notes');
-    }
-
-    return trimmed;
-  };
-
-  const sanitizedExperienceNotes = stripHtml(input.experience_notes);
-  const sanitizedCompanyNotes = stripHtml(input.company_notes);
+/**
+ * Sanitizes and validates notes fields
+ * @param experienceNotes - Optional experience notes
+ * @param companyNotes - Optional company notes
+ * @returns Object with sanitized notes
+ * @throws Error if length constraints are violated
+ */
+const sanitizeAndValidateNotes = (
+  experienceNotes?: string,
+  companyNotes?: string
+): { experience_notes?: string; company_notes?: string } => {
+  const sanitizedExperienceNotes = stripHtml(experienceNotes);
+  const sanitizedCompanyNotes = stripHtml(companyNotes);
 
   // Validate length constraints
   if (sanitizedExperienceNotes && sanitizedExperienceNotes.length > 2000) {
@@ -83,11 +108,36 @@ const validateVisitInput = (input: CreateVisitInput): CreateVisitInput => {
   }
 
   return {
+    experience_notes: sanitizedExperienceNotes,
+    company_notes: sanitizedCompanyNotes,
+  };
+};
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/**
+ * Validates and sanitizes visit input data
+ * @param input - Raw visit input data
+ * @returns Sanitized input data
+ * @throws Error if validation fails
+ */
+const validateVisitInput = (input: CreateVisitInput): CreateVisitInput => {
+  // Validate restaurant_id
+  if (!input.restaurant_id || input.restaurant_id.trim() === '') {
+    throw new Error('Restaurant ID is required');
+  }
+
+  validateRating(input.rating);
+  validateDate(input.visit_date);
+  const sanitizedNotes = sanitizeAndValidateNotes(input.experience_notes, input.company_notes);
+
+  return {
     restaurant_id: input.restaurant_id,
     visit_date: input.visit_date,
     rating: input.rating,
-    experience_notes: sanitizedExperienceNotes,
-    company_notes: sanitizedCompanyNotes,
+    ...sanitizedNotes,
   };
 };
 
@@ -98,54 +148,14 @@ const validateVisitInput = (input: CreateVisitInput): CreateVisitInput => {
  * @throws Error if validation fails
  */
 const validateUpdateInput = (input: UpdateVisitInput): UpdateVisitInput => {
-  // Validate rating - prevent 'unknown' and invalid values
-  const validRatings: PersonalAppreciation[] = ['avoid', 'fine', 'good', 'great'];
-  if (!validRatings.includes(input.rating)) {
-    throw new Error('Rating must be a valid appreciation level (avoid, fine, good, or great)');
-  }
-
-  // Validate date format (YYYY-MM-DD)
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.visit_date)) {
-    throw new Error('Invalid date format. Expected YYYY-MM-DD');
-  }
-
-  // Validate date range (not in future, not before 1900)
-  const visitDateStr = input.visit_date;
-  const todayStr = new Date().toISOString().split('T')[0];
-  const minDateStr = '1900-01-01';
-
-  if (visitDateStr < minDateStr || visitDateStr > todayStr) {
-    throw new Error('Visit date must be between 1900-01-01 and today');
-  }
-
-  // Sanitize text fields using same approach as create
-  const stripHtml = (text?: string): string | undefined => {
-    if (!text) return undefined;
-    const trimmed = text.trim();
-    if (!trimmed) return undefined;
-    if (/<|>|&/.test(trimmed)) {
-      throw new Error('HTML and special characters are not allowed in notes');
-    }
-    return trimmed;
-  };
-
-  const sanitizedExperienceNotes = stripHtml(input.experience_notes);
-  const sanitizedCompanyNotes = stripHtml(input.company_notes);
-
-  // Validate length constraints
-  if (sanitizedExperienceNotes && sanitizedExperienceNotes.length > 2000) {
-    throw new Error('Experience notes must be 2000 characters or less');
-  }
-
-  if (sanitizedCompanyNotes && sanitizedCompanyNotes.length > 500) {
-    throw new Error('Company notes must be 500 characters or less');
-  }
+  validateRating(input.rating);
+  validateDate(input.visit_date);
+  const sanitizedNotes = sanitizeAndValidateNotes(input.experience_notes, input.company_notes);
 
   return {
     visit_date: input.visit_date,
     rating: input.rating,
-    experience_notes: sanitizedExperienceNotes,
-    company_notes: sanitizedCompanyNotes,
+    ...sanitizedNotes,
   };
 };
 
@@ -312,7 +322,11 @@ export const visitService = {
       throw new Error('Visit not found');
     }
 
-    // Determine if this is a migrated placeholder being edited
+    // Migrated placeholder logic:
+    // - Visits migrated from the old system have is_migrated_placeholder = true
+    // - These visits have a default date (2024-01-01) since the old system didn't track dates
+    // - When user edits the date on a migrated visit, we clear the flag to indicate it's now a real date
+    // - This allows us to distinguish between "placeholder date" and "user-confirmed date"
     const isEditingMigratedDate = existingVisit.is_migrated_placeholder &&
                                    existingVisit.visit_date !== validatedInput.visit_date;
 
@@ -324,7 +338,7 @@ export const visitService = {
         rating: validatedInput.rating,
         experience_notes: validatedInput.experience_notes,
         company_notes: validatedInput.company_notes,
-        // Clear migrated flag if user is editing the date
+        // Clear migrated flag if user is editing the date (making it a real date now)
         is_migrated_placeholder: isEditingMigratedDate ? false : existingVisit.is_migrated_placeholder,
       })
       .eq('id', visitId)
@@ -351,7 +365,7 @@ export const visitService = {
   /**
    * Delete a visit
    * @param visitId - The visit ID to delete
-   * @throws Error if database operation fails
+   * @throws Error if database operation fails or visit not found
    */
   async deleteVisit(visitId: string): Promise<void> {
     // Get current user from Supabase auth
@@ -361,7 +375,22 @@ export const visitService = {
       throw new Error('User must be authenticated to delete visits');
     }
 
-    // Delete the visit (RLS policy ensures user can only delete their own visits)
+    // First check if visit exists and belongs to current user
+    const { data: existingVisit, error: fetchError } = await supabase
+      .from('restaurant_visits')
+      .select('id, user_id')
+      .eq('id', visitId)
+      .single();
+
+    if (fetchError || !existingVisit) {
+      throw new Error('Visit not found or you do not have permission to delete it');
+    }
+
+    if (existingVisit.user_id !== user.id) {
+      throw new Error('You do not have permission to delete this visit');
+    }
+
+    // Delete the visit (RLS policy provides additional security layer)
     const { error } = await supabase
       .from('restaurant_visits')
       .delete()
@@ -369,7 +398,7 @@ export const visitService = {
 
     if (error) {
       console.error('Error deleting visit:', error);
-      throw error;
+      throw new Error('Failed to delete visit. Please try again.');
     }
   },
 };

--- a/src/services/visits.ts
+++ b/src/services/visits.ts
@@ -16,6 +16,16 @@ interface CreateVisitInput {
 }
 
 /**
+ * Input data for updating an existing visit
+ */
+interface UpdateVisitInput {
+  visit_date: string; // ISO date string (YYYY-MM-DD)
+  rating: PersonalAppreciation;
+  experience_notes?: string;
+  company_notes?: string;
+}
+
+/**
  * Validates and sanitizes visit input data
  * @param input - Raw visit input data
  * @returns Sanitized input data
@@ -74,6 +84,64 @@ const validateVisitInput = (input: CreateVisitInput): CreateVisitInput => {
 
   return {
     restaurant_id: input.restaurant_id,
+    visit_date: input.visit_date,
+    rating: input.rating,
+    experience_notes: sanitizedExperienceNotes,
+    company_notes: sanitizedCompanyNotes,
+  };
+};
+
+/**
+ * Validates and sanitizes visit update input data
+ * @param input - Raw visit update input data
+ * @returns Sanitized input data
+ * @throws Error if validation fails
+ */
+const validateUpdateInput = (input: UpdateVisitInput): UpdateVisitInput => {
+  // Validate rating - prevent 'unknown' and invalid values
+  const validRatings: PersonalAppreciation[] = ['avoid', 'fine', 'good', 'great'];
+  if (!validRatings.includes(input.rating)) {
+    throw new Error('Rating must be a valid appreciation level (avoid, fine, good, or great)');
+  }
+
+  // Validate date format (YYYY-MM-DD)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.visit_date)) {
+    throw new Error('Invalid date format. Expected YYYY-MM-DD');
+  }
+
+  // Validate date range (not in future, not before 1900)
+  const visitDateStr = input.visit_date;
+  const todayStr = new Date().toISOString().split('T')[0];
+  const minDateStr = '1900-01-01';
+
+  if (visitDateStr < minDateStr || visitDateStr > todayStr) {
+    throw new Error('Visit date must be between 1900-01-01 and today');
+  }
+
+  // Sanitize text fields using same approach as create
+  const stripHtml = (text?: string): string | undefined => {
+    if (!text) return undefined;
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    if (/<|>|&/.test(trimmed)) {
+      throw new Error('HTML and special characters are not allowed in notes');
+    }
+    return trimmed;
+  };
+
+  const sanitizedExperienceNotes = stripHtml(input.experience_notes);
+  const sanitizedCompanyNotes = stripHtml(input.company_notes);
+
+  // Validate length constraints
+  if (sanitizedExperienceNotes && sanitizedExperienceNotes.length > 2000) {
+    throw new Error('Experience notes must be 2000 characters or less');
+  }
+
+  if (sanitizedCompanyNotes && sanitizedCompanyNotes.length > 500) {
+    throw new Error('Company notes must be 500 characters or less');
+  }
+
+  return {
     visit_date: input.visit_date,
     rating: input.rating,
     experience_notes: sanitizedExperienceNotes,
@@ -213,7 +281,98 @@ export const visitService = {
 
     return data;
   },
+
+  /**
+   * Update an existing visit
+   * @param visitId - The visit ID to update
+   * @param input - Updated visit data
+   * @returns The updated visit record
+   * @throws Error if validation fails or database operation fails
+   */
+  async updateVisit(visitId: string, input: UpdateVisitInput): Promise<RestaurantVisit> {
+    // Validate and sanitize input
+    const validatedInput = validateUpdateInput(input);
+
+    // Get current user from Supabase auth
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to update visits');
+    }
+
+    // Get the existing visit to check if date is being changed
+    const { data: existingVisit, error: fetchError } = await supabase
+      .from('restaurant_visits')
+      .select('*')
+      .eq('id', visitId)
+      .single();
+
+    if (fetchError) {
+      console.error('Error fetching visit for update:', fetchError);
+      throw new Error('Visit not found');
+    }
+
+    // Determine if this is a migrated placeholder being edited
+    const isEditingMigratedDate = existingVisit.is_migrated_placeholder &&
+                                   existingVisit.visit_date !== validatedInput.visit_date;
+
+    // Update visit record
+    const { data, error } = await supabase
+      .from('restaurant_visits')
+      .update({
+        visit_date: validatedInput.visit_date,
+        rating: validatedInput.rating,
+        experience_notes: validatedInput.experience_notes,
+        company_notes: validatedInput.company_notes,
+        // Clear migrated flag if user is editing the date
+        is_migrated_placeholder: isEditingMigratedDate ? false : existingVisit.is_migrated_placeholder,
+      })
+      .eq('id', visitId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating visit:', error);
+
+      // Check for duplicate visit on same date
+      if (error.code === '23505') { // Unique constraint violation
+        throw new Error(
+          `You already have a visit logged for this restaurant on ${validatedInput.visit_date}. ` +
+          'Please choose a different date.'
+        );
+      }
+
+      throw error;
+    }
+
+    return data;
+  },
+
+  /**
+   * Delete a visit
+   * @param visitId - The visit ID to delete
+   * @throws Error if database operation fails
+   */
+  async deleteVisit(visitId: string): Promise<void> {
+    // Get current user from Supabase auth
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to delete visits');
+    }
+
+    // Delete the visit (RLS policy ensures user can only delete their own visits)
+    const { error } = await supabase
+      .from('restaurant_visits')
+      .delete()
+      .eq('id', visitId);
+
+    if (error) {
+      console.error('Error deleting visit:', error);
+      throw error;
+    }
+  },
 };
 
-// Export the CreateVisitInput type for use in components
-export type { CreateVisitInput };
+// Export types for use in components
+export type { CreateVisitInput, UpdateVisitInput };

--- a/tests/components/VisitModal.test.tsx
+++ b/tests/components/VisitModal.test.tsx
@@ -10,6 +10,7 @@ import { visitService } from '@/services/visits';
 vi.mock('@/services/visits', () => ({
   visitService: {
     addVisit: vi.fn(),
+    updateVisit: vi.fn(),
   },
 }));
 
@@ -350,6 +351,66 @@ describe('VisitModal', () => {
 
       expect(screen.getByText('Update Visit')).toBeInTheDocument();
       expect(screen.queryByText('Add Visit')).not.toBeInTheDocument();
+    });
+
+    it('should call updateVisit when editing a visit', async () => {
+      const mockUpdateVisit = vi.spyOn(visitService, 'updateVisit').mockResolvedValueOnce({
+        id: 'visit-1',
+        restaurant_id: 'test-restaurant',
+        user_id: 'user-1',
+        visit_date: '2026-02-20',
+        rating: 'great',
+        experience_notes: 'Even better this time',
+        company_notes: 'With family',
+        is_migrated_placeholder: false,
+        created_at: '2026-02-15T12:00:00Z',
+        updated_at: '2026-03-01T12:00:00Z',
+      });
+
+      const visitToEdit = {
+        id: 'visit-1',
+        restaurant_id: 'test-restaurant',
+        user_id: 'user-1',
+        visit_date: '2026-02-15',
+        rating: 'good' as const,
+        experience_notes: 'Great meal',
+        company_notes: 'With friends',
+        is_migrated_placeholder: false,
+        created_at: '2026-02-15T12:00:00Z',
+        updated_at: '2026-02-15T12:00:00Z',
+      };
+
+      render(<VisitModal {...defaultProps} visitToEdit={visitToEdit} />);
+
+      // Change the date
+      const dateInput = screen.getByLabelText(/visit date/i);
+      fireEvent.change(dateInput, { target: { value: '2026-02-20' } });
+
+      // Change rating
+      const greatButton = screen.getByText('Must visit!');
+      fireEvent.click(greatButton);
+
+      // Change notes
+      const experienceTextarea = screen.getByPlaceholderText(/What did you have/i);
+      fireEvent.change(experienceTextarea, { target: { value: 'Even better this time' } });
+
+      const companyInput = screen.getByPlaceholderText(/Sarah and Tom/i);
+      fireEvent.change(companyInput, { target: { value: 'With family' } });
+
+      // Submit
+      const submitButton = screen.getByRole('button', { name: /Update Visit/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockUpdateVisit).toHaveBeenCalledWith('visit-1', {
+          visit_date: '2026-02-20',
+          rating: 'great',
+          experience_notes: 'Even better this time',
+          company_notes: 'With family',
+        });
+        expect(defaultProps.onSuccess).toHaveBeenCalled();
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/tests/pages/RestaurantDetails.test.tsx
+++ b/tests/pages/RestaurantDetails.test.tsx
@@ -1,0 +1,311 @@
+// ABOUT: Component tests for RestaurantDetails page
+// ABOUT: Tests visit deletion flow including confirmation dialog
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import RestaurantDetails from '@/pages/RestaurantDetails';
+import { visitService } from '@/services/visits';
+import { restaurantService } from '@/services/restaurants';
+
+// Mock services
+vi.mock('@/services/visits', () => ({
+  visitService: {
+    deleteVisit: vi.fn(),
+    getVisitsByRestaurant: vi.fn(),
+    getLatestVisits: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/restaurants', () => ({
+  restaurantService: {
+    getRestaurantByIdWithLocations: vi.fn(),
+  },
+}));
+
+// Mock auth context
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user-id', email: 'test@example.com' },
+  }),
+}));
+
+// Mock toast
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+// Mock InteractiveMap to avoid WebGL errors
+vi.mock('@/components/InteractiveMap', () => ({
+  InteractiveMap: () => <div data-testid="interactive-map">Map</div>,
+}));
+
+// Mock router params
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ id: 'test-restaurant-id' }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+};
+
+describe('RestaurantDetails - Visit Deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock restaurant data
+    vi.mocked(restaurantService.getRestaurantByIdWithLocations).mockResolvedValue({
+      id: 'test-restaurant-id',
+      name: 'Test Restaurant',
+      address: 'Test Address',
+      status: 'visited',
+      locations: [{
+        id: 'loc-1',
+        restaurant_id: 'test-restaurant-id',
+        location_name: 'Main Location',
+        full_address: '123 Test St',
+        latitude: 51.5,
+        longitude: -0.1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+
+    // Mock visits data
+    vi.mocked(visitService.getLatestVisits).mockResolvedValue([
+      {
+        id: 'visit-1',
+        restaurant_id: 'test-restaurant-id',
+        user_id: 'test-user-id',
+        visit_date: '2026-02-15',
+        rating: 'good',
+        experience_notes: 'Great meal',
+        company_notes: 'With friends',
+        is_migrated_placeholder: false,
+        created_at: '2026-02-15T12:00:00Z',
+        updated_at: '2026-02-15T12:00:00Z',
+      },
+    ]);
+  });
+
+  it('should show confirmation dialog when delete button clicked', async () => {
+    render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Find and click delete button
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    // Confirmation dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+      expect(screen.getByText(/are you sure you want to delete this visit/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should delete visit when confirmed', async () => {
+    const mockDeleteVisit = vi.mocked(visitService.deleteVisit);
+    mockDeleteVisit.mockResolvedValueOnce(undefined);
+
+    render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Click delete button
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    // Confirm deletion
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /delete/i });
+    fireEvent.click(confirmButton);
+
+    // Verify deleteVisit was called
+    await waitFor(() => {
+      expect(mockDeleteVisit).toHaveBeenCalledWith('visit-1');
+    });
+  });
+
+  it('should cancel deletion when dialog cancelled', async () => {
+    const mockDeleteVisit = vi.mocked(visitService.deleteVisit);
+
+    render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Click delete button
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    // Wait for dialog
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+    });
+
+    // Click cancel
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelButton);
+
+    // Verify deleteVisit was NOT called
+    expect(mockDeleteVisit).not.toHaveBeenCalled();
+
+    // Dialog should close
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Visit')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show error toast on delete failure', async () => {
+    const mockDeleteVisit = vi.mocked(visitService.deleteVisit);
+    mockDeleteVisit.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Click delete and confirm
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /delete/i });
+    fireEvent.click(confirmButton);
+
+    // Verify error handling was triggered
+    await waitFor(() => {
+      expect(mockDeleteVisit).toHaveBeenCalled();
+    });
+  });
+
+  it('should show success toast on delete success', async () => {
+    const mockDeleteVisit = vi.mocked(visitService.deleteVisit);
+    mockDeleteVisit.mockResolvedValueOnce(undefined);
+
+    render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Click delete and confirm
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /delete/i });
+    fireEvent.click(confirmButton);
+
+    // Verify delete was successful
+    await waitFor(() => {
+      expect(mockDeleteVisit).toHaveBeenCalledWith('visit-1');
+      // Dialog should close after success
+      expect(screen.queryByText('Delete Visit')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should invalidate queries after successful delete', async () => {
+    const mockDeleteVisit = vi.mocked(visitService.deleteVisit);
+    mockDeleteVisit.mockResolvedValueOnce(undefined);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </BrowserRouter>
+    );
+
+    render(<RestaurantDetails />, { wrapper: Wrapper });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Restaurant')).toBeInTheDocument();
+    });
+
+    // Click delete and confirm
+    const deleteButton = screen.getByRole('button', { name: /delete visit/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Visit')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /delete/i });
+    fireEvent.click(confirmButton);
+
+    // Verify queries were invalidated
+    await waitFor(() => {
+      expect(mockDeleteVisit).toHaveBeenCalledWith('visit-1');
+    });
+
+    // Check invalidation calls
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    }, { timeout: 3000 });
+
+    // Verify the correct queries were invalidated
+    const calls = invalidateSpy.mock.calls;
+    expect(calls.some(call =>
+      call[0]?.queryKey?.[0] === 'restaurant' &&
+      call[0]?.queryKey?.[1] === 'test-restaurant-id'
+    )).toBe(true);
+    expect(calls.some(call =>
+      call[0]?.queryKey?.[0] === 'restaurants'
+    )).toBe(true);
+  });
+});

--- a/tests/services/visits.test.ts
+++ b/tests/services/visits.test.ts
@@ -359,3 +359,321 @@ describe('visitService.getVisitCount', () => {
     expect(result).toBe(0);
   });
 });
+
+describe('visitService.updateVisit - Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('XSS Prevention', () => {
+    it('should reject experience notes with HTML characters', async () => {
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'good' as const,
+        experience_notes: 'Great meal <script>alert(1)</script>',
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'HTML and special characters are not allowed in notes'
+      );
+    });
+
+    it('should reject company notes with HTML characters', async () => {
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'good' as const,
+        company_notes: '<b>Sarah</b>',
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'HTML and special characters are not allowed in notes'
+      );
+    });
+  });
+
+  describe('Rating Validation', () => {
+    it('should reject invalid rating values', async () => {
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'excellent' as any,
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'Rating must be a valid appreciation level'
+      );
+    });
+
+    it('should accept valid ratings', async () => {
+      // Mock existing visit fetch and update
+      const { supabase } = await import('@/lib/supabase');
+      vi.mocked(supabase.from).mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({
+              data: {
+                id: 'visit-123',
+                restaurant_id: 'restaurant-1',
+                user_id: 'test-user-id',
+                visit_date: '2026-03-01',
+                rating: 'good',
+                is_migrated_placeholder: false,
+                created_at: '2026-03-01T00:00:00Z',
+                updated_at: '2026-03-01T00:00:00Z',
+              },
+              error: null,
+            })),
+          })),
+        })),
+      } as any).mockReturnValueOnce({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({
+                data: {
+                  id: 'visit-123',
+                  restaurant_id: 'restaurant-1',
+                  user_id: 'test-user-id',
+                  visit_date: '2026-03-01',
+                  rating: 'great',
+                  is_migrated_placeholder: false,
+                  created_at: '2026-03-01T00:00:00Z',
+                  updated_at: '2026-03-01T12:00:00Z',
+                },
+                error: null,
+              })),
+            })),
+          })),
+        })),
+      } as any);
+
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'great' as const,
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).resolves.toBeDefined();
+    });
+  });
+
+  describe('Date Validation', () => {
+    it('should reject invalid date format', async () => {
+      const input = {
+        visit_date: '03/01/2026',
+        rating: 'good' as const,
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'Invalid date format. Expected YYYY-MM-DD'
+      );
+    });
+
+    it('should reject future dates', async () => {
+      const input = {
+        visit_date: '2099-12-31',
+        rating: 'good' as const,
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'Visit date must be between 1900-01-01 and today'
+      );
+    });
+
+    it('should accept valid dates', async () => {
+      // Mock existing visit fetch and update
+      const { supabase } = await import('@/lib/supabase');
+      vi.mocked(supabase.from).mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({
+              data: {
+                id: 'visit-123',
+                restaurant_id: 'restaurant-1',
+                user_id: 'test-user-id',
+                visit_date: '2026-02-10',
+                rating: 'good',
+                is_migrated_placeholder: false,
+                created_at: '2026-02-10T00:00:00Z',
+                updated_at: '2026-02-10T00:00:00Z',
+              },
+              error: null,
+            })),
+          })),
+        })),
+      } as any).mockReturnValueOnce({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({
+                data: {
+                  id: 'visit-123',
+                  restaurant_id: 'restaurant-1',
+                  user_id: 'test-user-id',
+                  visit_date: '2026-02-15',
+                  rating: 'good',
+                  is_migrated_placeholder: false,
+                  created_at: '2026-02-10T00:00:00Z',
+                  updated_at: '2026-03-01T12:00:00Z',
+                },
+                error: null,
+              })),
+            })),
+          })),
+        })),
+      } as any);
+
+      const input = {
+        visit_date: '2026-02-15',
+        rating: 'good' as const,
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).resolves.toBeDefined();
+    });
+  });
+
+  describe('Character Length Validation', () => {
+    it('should reject experience notes longer than 2000 characters', async () => {
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'good' as const,
+        experience_notes: 'x'.repeat(2001),
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'Experience notes must be 2000 characters or less'
+      );
+    });
+
+    it('should reject company notes longer than 500 characters', async () => {
+      const input = {
+        visit_date: '2026-03-01',
+        rating: 'good' as const,
+        company_notes: 'x'.repeat(501),
+      };
+
+      await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+        'Company notes must be 500 characters or less'
+      );
+    });
+  });
+});
+
+describe('visitService.updateVisit - Functionality', () => {
+  it('should clear migrated placeholder flag when date is changed', async () => {
+    // Mock the existing visit fetch to return a migrated placeholder
+    const { supabase } = await import('@/lib/supabase');
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: {
+              id: 'visit-123',
+              restaurant_id: 'restaurant-1',
+              user_id: 'test-user-id',
+              visit_date: '2025-01-01',
+              rating: 'good',
+              is_migrated_placeholder: true,
+              created_at: '2025-01-01T00:00:00Z',
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+            error: null,
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({
+              data: {
+                id: 'visit-123',
+                restaurant_id: 'restaurant-1',
+                user_id: 'test-user-id',
+                visit_date: '2026-02-15',
+                rating: 'great',
+                is_migrated_placeholder: false,
+                created_at: '2025-01-01T00:00:00Z',
+                updated_at: '2026-03-01T12:00:00Z',
+              },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    } as any);
+
+    const input = {
+      visit_date: '2026-02-15',
+      rating: 'great' as const,
+    };
+
+    const result = await visitService.updateVisit('visit-123', input);
+    expect(result.is_migrated_placeholder).toBe(false);
+  });
+
+  it('should handle duplicate visit date', async () => {
+    const { supabase } = await import('@/lib/supabase');
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: {
+              id: 'visit-123',
+              restaurant_id: 'restaurant-1',
+              user_id: 'test-user-id',
+              visit_date: '2026-02-15',
+              rating: 'good',
+              is_migrated_placeholder: false,
+              created_at: '2026-02-15T00:00:00Z',
+              updated_at: '2026-02-15T00:00:00Z',
+            },
+            error: null,
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({
+              data: null,
+              error: { code: '23505' }, // Unique constraint violation
+            })),
+          })),
+        })),
+      })),
+    } as any);
+
+    const input = {
+      visit_date: '2026-02-20',
+      rating: 'great' as const,
+    };
+
+    await expect(visitService.updateVisit('visit-123', input)).rejects.toThrow(
+      'You already have a visit logged for this restaurant on 2026-02-20'
+    );
+  });
+});
+
+describe('visitService.deleteVisit', () => {
+  it('should delete a visit successfully', async () => {
+    const { supabase } = await import('@/lib/supabase');
+    vi.mocked(supabase.from).mockReturnValue({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      })),
+    } as any);
+
+    await expect(visitService.deleteVisit('visit-123')).resolves.not.toThrow();
+  });
+
+  it('should handle deletion errors', async () => {
+    const { supabase } = await import('@/lib/supabase');
+    vi.mocked(supabase.from).mockReturnValue({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({
+          error: new Error('Database error'),
+        })),
+      })),
+    } as any);
+
+    await expect(visitService.deleteVisit('visit-123')).rejects.toThrow();
+  });
+});

--- a/tests/services/visits.test.ts
+++ b/tests/services/visits.test.ts
@@ -655,25 +655,83 @@ describe('visitService.updateVisit - Functionality', () => {
 describe('visitService.deleteVisit', () => {
   it('should delete a visit successfully', async () => {
     const { supabase } = await import('@/lib/supabase');
+
+    // Mock select to find the visit
+    const selectMock = vi.fn(() => Promise.resolve({
+      data: {
+        id: 'visit-123',
+        user_id: 'test-user-id',
+      },
+      error: null,
+    }));
+
+    // Mock delete operation
+    const deleteMock = vi.fn(() => Promise.resolve({ error: null }));
+
     vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: selectMock,
+        })),
+      })),
       delete: vi.fn(() => ({
-        eq: vi.fn(() => Promise.resolve({ error: null })),
+        eq: deleteMock,
       })),
     } as any);
 
     await expect(visitService.deleteVisit('visit-123')).resolves.not.toThrow();
   });
 
-  it('should handle deletion errors', async () => {
+  it('should throw error when visit not found', async () => {
     const { supabase } = await import('@/lib/supabase');
+
+    // Mock select returning no visit
     vi.mocked(supabase.from).mockReturnValue({
-      delete: vi.fn(() => ({
-        eq: vi.fn(() => Promise.resolve({
-          error: new Error('Database error'),
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: null,
+            error: { code: 'PGRST116', message: 'Not found' },
+          })),
         })),
       })),
     } as any);
 
-    await expect(visitService.deleteVisit('visit-123')).rejects.toThrow();
+    await expect(visitService.deleteVisit('visit-123')).rejects.toThrow(
+      'Visit not found or you do not have permission to delete it'
+    );
+  });
+
+  it('should handle deletion errors', async () => {
+    const { supabase } = await import('@/lib/supabase');
+
+    // Mock select to find the visit
+    const selectMock = vi.fn(() => Promise.resolve({
+      data: {
+        id: 'visit-123',
+        user_id: 'test-user-id',
+      },
+      error: null,
+    }));
+
+    // Mock delete operation failing
+    const deleteMock = vi.fn(() => Promise.resolve({
+      error: new Error('Database error'),
+    }));
+
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: selectMock,
+        })),
+      })),
+      delete: vi.fn(() => ({
+        eq: deleteMock,
+      })),
+    } as any);
+
+    await expect(visitService.deleteVisit('visit-123')).rejects.toThrow(
+      'Failed to delete visit. Please try again.'
+    );
   });
 });


### PR DESCRIPTION
## Summary
Implements Phase 4 of the visit logging system: edit and delete capabilities for restaurant visits.

## Changes

### Service Layer (`src/services/visits.ts`)
- ✅ `updateVisit()` - update existing visits with validation
- ✅ `deleteVisit()` - remove visits from history
- ✅ Clears `is_migrated_placeholder` flag when editing dates
- ✅ Handles duplicate date conflicts
- ✅ 13 new service tests (41 total visit service tests)

### UI Components
- ✅ **VisitHistory**: Edit/delete action buttons for each visit
- ✅ **VisitModal**: Edit mode support (pre-fills form, calls updateVisit)
- ✅ **RestaurantDetails**: Delete confirmation dialog (AlertDialog)
- ✅ Query invalidation to refresh data after edit/delete

### Tests
- ✅ Service tests for updateVisit validation (XSS, rating, date, length)
- ✅ Service tests for delete functionality
- ✅ Component test for edit mode submission
- ✅ **100 tests passing** across entire project

### Security
- XSS prevention (same strict character rejection as create)
- Rating validation (prevents invalid values)
- Date validation (clears migrated flag appropriately)
- RLS policies protect user data (users only edit/delete own visits)

## Key User Flows

**Edit Visit:**
1. Click edit button on visit card
2. Modal opens pre-filled with visit data
3. Modify date/rating/notes
4. Submit → visit updated, queries invalidated, toast notification

**Delete Visit:**
1. Click delete button on visit card
2. Confirmation dialog appears
3. Confirm → visit deleted, queries invalidated, toast notification

**Fix Placeholder Dates:**
1. Edit a migrated visit (shows "Before 2026")
2. Change date to actual visit date
3. `is_migrated_placeholder` automatically cleared
4. Date now displays normally (e.g., "Feb 15, 2026")

## Testing Checklist
- [x] Service layer tests passing (41 tests)
- [x] Component tests passing (21 tests)
- [x] TypeScript compilation succeeds
- [x] All 100 project tests passing
- [ ] Manual testing (pending)
- [ ] Documentation updates (pending)

## Related
- Phase 3: #4 (merged)
- Spec: `SPECIFICATIONS/visit_logging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)