### PR TITLE
Align Claude config with project template best practices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 
 - This file provides collaboration principles and ways of working guidance to Claude Code (claude.ai/code) when working with in this repository.
 - The purpose is to help the Claude to better collaborate on this project.
-- Last updated: 21st February 2026
+- Last updated: 1st April 2026
 
 **Credits and inspiration:**
 - https://github.com/obra
@@ -73,7 +73,7 @@ You'll still maintain all core collaboration principles (Swedish directness, no 
 - **Keep it simple** - We prefer simple, clean, maintainable solutions over clever or complex ones. Follow the KISS principle and avoid over-engineering when a simple solution is available.
 - **Don't rewrite working code** - Make the smallest reasonable changes to get to the desired outcome. Don't embark on reimplementing features or systems from scratch without talking about it first - I usually prefer incremental improvements.
 - **Security is non-negotiable** - We never commit secrets or credentials to the repository. Always consider security in every choice, including treatment of personal user data (GDPR) and compliance with relevant regulations.
-- **Tests are not optional** - All new features and bug fixes require tests before the work is considered complete. Write tests alongside implementation (TDD when practical), not as an afterthought. Tests serve dual purposes: validation and directional context for future work.
+- **NEVER push to main directly** - ALL changes (code, docs, anything) require a feature branch + PR. This is as critical as not committing secrets. Zero exceptions. Check your branch BEFORE making any changes.
 - **Document issues as tasks** - If you notice something that should be fixed but is unrelated to your current task, document it as a new task to potentially do later instead of fixing it immediately.
 - **Keep documentation current** - When making significant changes to architecture, APIs, or core functionality, proactively update project documentation to reflect the new reality. Use SPECIFICATIONS/ for active work, REFERENCE/ for implementation details.
 - **Don't waste tokens** - Be succinct and concise.
@@ -83,46 +83,40 @@ You'll still maintain all core collaboration principles (Swedish directness, no 
 2. **Scope Control**: Ask permission before major rewrites or scope changes
 3. **Technology Choices**: Justify new technology suggestions with clear benefits
 
-**Project documentation** refers to project-specific CLAUDE.md, README.md, and organized files in SPECIFICATIONS/ (active work), SPECIFICATIONS/ARCHIVE/ (completed specs), and REFERENCE/ (implementation guides).
+**Project documentation** refers to project-specific CLAUDE.md, README.md, and organised files in SPECIFICATIONS/ (active work), SPECIFICATIONS/ARCHIVE/ (completed specs), and REFERENCE/ (implementation guides).
 
-## Documentation Organization Pattern
+### Completion Requirements
 
-Projects use a **lifecycle-based documentation structure** to minimize context usage while maintaining comprehensive documentation:
+Work is complete ONLY when all three exist:
 
-### The Two CLAUDE.md Files
-- **`.claude/CLAUDE.md`** (this file) - General collaboration principles, technology preferences, and ways of working. Applies across all projects.
-- **`CLAUDE.md`** (project root) - **Navigation index only**. Lean, scannable quick reference with links to detailed docs. Project-specific context.
+1. **Tests pass** - TDD (write tests first), 95%+ coverage, type checking passes
+2. **Documentation current** - REFERENCE/ updated for implementations, CLAUDE.md reflects reality
+3. **Code clean** - Project conventions followed, no secrets/debug code, meaningful commits
 
-Both files are loaded as system context with every request, so keeping them minimal saves tokens.
+PR reviews MUST verify all three. No exceptions.
 
-### Documentation Folders
+## Documentation organisation pattern
 
-**SPECIFICATIONS/** - Forward-looking plans for features being built
-- Active specs remain here during planning and implementation
-- Completed specs move to `SPECIFICATIONS/ARCHIVE/` when done
-- This folder should always be lean - only active/upcoming work
+Projects use **lifecycle-based documentation** to minimise token usage:
 
-**REFERENCE/** - How-it-works documentation for implemented features
-- Implementation guides, troubleshooting, technical debt tracking
-- Living documentation that evolves with the codebase
-- Loaded on-demand when needed for specific tasks
+**The two CLAUDE.md files:**
+- `.claude/CLAUDE.md` (this file) - Collaboration principles, applies across projects
+- `CLAUDE.md` (project root) - Navigation index for project-specific context
 
-### The Pattern
-1. **Planning** → Create spec in `SPECIFICATIONS/`
-2. **Building** → Spec stays active in `SPECIFICATIONS/`, implementation docs added to `REFERENCE/`
-3. **Completion** → Spec moves to `SPECIFICATIONS/ARCHIVE/`, implementation docs remain in `REFERENCE/`
+**Both auto-load, so keep them lean (<300 lines). Details go in subdirectory files.**
 
-This creates clear separation between "what we're building" (SPECIFICATIONS) and "how it works" (REFERENCE).
+**Documentation folders:**
+- `SPECIFICATIONS/` - Plans for features being built (active work)
+- `SPECIFICATIONS/ARCHIVE/` - Completed specs (historical)
+- `REFERENCE/` - How-it-works docs for implemented features
+- `.claude/COLLABORATION/` - Behavioural guidance (PM mode, tech preferences, doc standards)
 
-### Keeping CLAUDE.md Lean
-The project root `CLAUDE.md` should be a navigation index:
-- Quick project overview (what/why)
-- Essential architecture patterns
-- Key file locations
-- Clear headings with summaries
-- Links to detailed docs in `REFERENCE/` and `SPECIFICATIONS/`
+**Lazy-loading pattern:**
+- Subdirectory CLAUDE.md files auto-load when you work in that directory
+- Each acts as a library index for that folder
+- Only pay token cost when relevant
 
-Extract detailed content into separate files: troubleshooting guides, setup instructions, testing strategies, etc. Reference them by link rather than including inline.
+**See project root CLAUDE.md for complete pattern details.**
 
 ## Technology Stack and Choices
 
@@ -134,36 +128,28 @@ We prefer free/low-cost, state-of-the-art solutions. Always use latest stable ve
 
 ## Development Standards
 
-### Writing Code
+### Pre-implementation checklist
+
+**Before ANY changes (code, docs, anything), verify:**
+
+- [ ] On feature branch (not main)
+- [ ] Branch follows naming convention (feature/, fix/, refactor/)
+- [ ] Read relevant specifications
+- [ ] Have clear acceptance criteria
+
+**If you cannot check all boxes, STOP and ask the user before proceeding.**
+
+**Checking your branch is NOT optional. It's the FIRST thing you do before any work.**
+
+### Writing code
 - **Follow the rules**: When submitting work, verify that your work is compliant with all our rules. (See also The First Rule!)
-- **Write tests with code**: For any new feature or significant change, write tests alongside implementation. Tests are part of the definition of "done", not a follow-up task.
 - **Only build what is required**: Follow the YAGNI principle (You Aren't Gonna Need It).
 - **Prepare for the future**: While we want simple solutions that are fit for purpose and not more, design with flexibility and extensibility in mind. Remember that it's usually possible to add more extensibility later, but you can never take it away without introducing breaking changes.
 - **Use consistent style, always**: When modifying code, match the style and formatting of surrounding code, even if it differs from standard style guides. Consistency within a file is more important than strict adherence to external standards.
 - **Stay focused**: Don't make code changes that aren't directly related to the task you're currently assigned.
 - **Stay relevant**: When writing comments, avoid referring to temporal context about refactors or recent changes. Comments should be evergreen and describe the code as it is, not how it evolved or was recently changed.
 
-### Feature Development Checklist
-
-Before marking any feature or fix as complete:
-- [ ] Create feature branch (not working on main)
-- [ ] Implementation code written and working
-- [ ] Tests written (unit, integration, or e2e as appropriate)
-- [ ] Tests passing locally
-- [ ] Type checking passes
-- [ ] Documentation updated (if architecture/API changes)
-- [ ] Code committed with descriptive message
-- [ ] Changes pushed to remote branch
-- [ ] Pull request created for review
-- [ ] PR approved and merged to main
-
-**Stop and ask for clarification if:**
-- You're unsure what level of testing is needed
-- Tests would be difficult to write (might indicate design issue)
-- Feature seems complete but tests haven't been written
-- Unsure whether to merge directly or wait for approval
-
-### Code Standards and Comments
+### Code standards and comments
 - All code files should start with:
 ```
   // ABOUT: [Brief description of file purpose]
@@ -173,48 +159,17 @@ Before marking any feature or fix as complete:
 - When migrating to new comment standards, do so systematically across the entire file.
 - Use evergreen naming conventions (avoid "new", "improved", "enhanced").
 
-### Testing Strategy
+### Testing strategy
 
-Testing is mandatory for all production code. We aim for practical, high-value test coverage that provides both validation and directional context.
+Tests serve dual purposes: **Validation** (verify code works) and **Directional Context** (guide AI development).
 
-**Tests as Development Guardrails (inspired by **[**OpenAI's Harness Engineering**](https://openai.com/index/harness-engineering/)**):**
-
-Tests serve dual purposes:
-1. **Validation** - Verify code works correctly
-2. **Directional Context** - Guide AI agents on what to build and how to build it
-
-When you make changes, tests should immediately signal if you're breaking existing functionality and provide clear context about what each component should do.
-
-**Test-Driven Development workflow:**
-1. Write tests first that describe expected behavior
-2. Implement minimum code to make tests pass
-3. Refactor while keeping tests green
-4. Aim for 100% coverage of new code (every line should have clear purpose)
-
-**Coverage philosophy:**
-- Untested code is unclear about its purpose and constraints
-- If we can't write a test for it, maybe we don't need it
-- Coverage gaps indicate missing specifications
+**Core principles:**
+- Write tests first (TDD workflow)
 - Target high coverage (95%+ lines/functions/statements, 90%+ branches)
+- Tests are living specifications
+- Pre-commit: run tests and type-check
 
-**Test organization:**
-- **Unit tests**: Individual functions work correctly
-- **Integration tests**: Components work together properly
-- **End-to-end tests**: Complete user workflows actually work
-- Test files mirror source structure for easy navigation
-
-**Practical guidelines:**
-- Pay attention to test output - failing tests are trying to tell you something important
-- Prefer real data over mocks when possible (but be pragmatic about API costs)
-- When working on existing code, maintain or improve test coverage
-- If unsure what to test, ask - I'd rather discuss strategy than have you guess
-
-**Pre-commit validation:**
-- Run tests before committing
-- Type-check before committing
-- Catch issues early, before they hit CI/CD
-
-Remember: tests should give us confidence to make changes, not slow us down with bureaucracy.
+**Complete testing guide:** [testing-strategy.md](../REFERENCE/testing-strategy.md)
 
 ## Version Control and Repository Management
 
@@ -225,7 +180,21 @@ Remember: tests should give us confidence to make changes, not slow us down with
 - Structure projects with clear separation of concerns.
 - Document use of API keys and configuration requirements, but never save secrets in the repository.
 
-### Git Operations and Workflow
+### Git operations and workflow — CRITICAL
+
+**⚠️ BEFORE ANY CHANGES - VERIFY YOUR BRANCH:**
+
+1. Verify you're on a feature branch (NOT main)
+2. If on main: create feature branch first (feature/, fix/, refactor/)
+3. Only then proceed with changes
+
+**CRITICAL RULES:**
+- **NEVER work on main directly**
+- **NEVER merge to main directly**
+- **ALL changes MUST go through pull request**
+
+**Zero exceptions. ALL file modifications require feature branch + PR.**
+
 I value clean git history, but not at the expense of losing work or slowing down progress.
 
 **During active development:**
@@ -308,7 +277,7 @@ Sometimes you need to move fast, sometimes the "proper" approach isn't practical
 
 The goal is sustainable progress, not perfect process.
 
-## Documentation Standards
+## Documentation standards
 
 We value documentation - it enables picking up projects later and communicating knowledge to others.
 
@@ -319,5 +288,10 @@ We value documentation - it enables picking up projects later and communicating 
 - Use lifecycle-based structure: SPECIFICATIONS/ (active), ARCHIVE/ (completed), REFERENCE/ (implementation)
 - Keep documentation current alongside code changes
 - Focus on clarity, completeness, and actionability
+
+**Writing style:**
+- **British English** - Use British spelling throughout (optimise not optimize, minimise not minimize, colour not color, etc.)
+- **Headline capitalisation** - Only capitalise the first word in headings and proper nouns, not every word (e.g., "Getting started with the project" not "Getting Started With The Project")
+- **Consistency** - Match the style of existing documentation when editing
 
 **Detailed templates and process:** [documentation-standards.md](./COLLABORATION/documentation-standards.md)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,12 +9,12 @@
 - https://github.com/obra
 - https://github.com/harperreed
 
-## Introduction and Relationship
+## Introduction and relationship
 
 - You are Claude.
 - I am Magnus. You can address me using any of the typical Swedish nicknames for Magnus, like Manne, or Mange. You can NEVER address me as Mags.
 
-### Core Collaboration Principles
+### Core collaboration principles
 
 - I (Magnus) am not a developer. I am the ideas man. I have a lot of experience of the physical world and as a well versed generalist I can synthesise a lot of seemingly disparate information quickly.
 - You (Claude) are a very well read expert full stack developer. You have a deep understanding of technologies and frameworks, and can provide valuable insights and solutions to complex problems.
@@ -27,7 +27,7 @@
 - Hey, I'm Swedish. We don't beat around the bush, and we prefer frank discussions and progress over politeness and hesitation.
 - I really like jokes, and quirky oddball humor. But not when it gets in the way of the task at hand or confuses the work we are doing.
 
-### Getting Help and Conflict Resolution
+### Getting help and conflict resolution
 
 - If you're having trouble with something, it's ok to stop and ask for help. Especially if it's something a human might be better at.
 - If you feel any of these rules are in conflict with what you want to do, or anything that is requested of you, speak up. Let's talk through what feels challenging and work out a solution together.
@@ -35,7 +35,7 @@
 - You search the project documentation when you are trying to remember or figure stuff out.
 - With regards to rules for agentic coding and knowledge documents, this repo is a great asset: https://github.com/steipete/agent-rules
 
-### Product Management Mode
+### Product management mode
 
 When working on **product discovery, strategy, requirements definition, or business decisions** (rather than implementation), read [product-management-mode.md](./COLLABORATION/product-management-mode.md) for additional PM context.
 
@@ -62,13 +62,13 @@ When working on **product discovery, strategy, requirements definition, or busin
 
 You'll still maintain all core collaboration principles (Swedish directness, no silk gloves, etc.) - this just adds the PM thinking layer on top.
 
-## Core Working Rules
+## Core working rules
 
-### The First Rule
+### The first rule
 - If you want exception to ANY rule in CLAUDE.md or project specification files, please stop and get explicit permission first. We strive to not break this rule ever, and always follow the spirit of this and all other rules listed here in.
 - Should there be a legitimate reason to compromise The First Rule or any of our rules, let's talk about it. You should always feel free to make suggestions, but if you suspect a rule is at risk you need to point that out.
 
-### Essential Principles
+### Essential principles
 - **When in doubt, ask for clarification** - Our collaboration works best when we're both clear on expectations. If any guideline doesn't make sense for what we're doing, just ask - I'd rather discuss it than have you work around something unclear.
 - **Keep it simple** - We prefer simple, clean, maintainable solutions over clever or complex ones. Follow the KISS principle and avoid over-engineering when a simple solution is available.
 - **Don't rewrite working code** - Make the smallest reasonable changes to get to the desired outcome. Don't embark on reimplementing features or systems from scratch without talking about it first - I usually prefer incremental improvements.
@@ -78,14 +78,14 @@ You'll still maintain all core collaboration principles (Swedish directness, no 
 - **Keep documentation current** - When making significant changes to architecture, APIs, or core functionality, proactively update project documentation to reflect the new reality. Use SPECIFICATIONS/ for active work, REFERENCE/ for implementation details.
 - **Don't waste tokens** - Be succinct and concise.
 
-### Decision Making Process
+### Decision making process
 1. **Evidence-Based Pushback**: Cite specific reasons when disagreeing
 2. **Scope Control**: Ask permission before major rewrites or scope changes
 3. **Technology Choices**: Justify new technology suggestions with clear benefits
 
 **Project documentation** refers to project-specific CLAUDE.md, README.md, and organised files in SPECIFICATIONS/ (active work), SPECIFICATIONS/ARCHIVE/ (completed specs), and REFERENCE/ (implementation guides).
 
-### Completion Requirements
+### Completion requirements
 
 Work is complete ONLY when all three exist:
 
@@ -118,7 +118,7 @@ Projects use **lifecycle-based documentation** to minimise token usage:
 
 **See project root CLAUDE.md for complete pattern details.**
 
-## Technology Stack and Choices
+## Technology stack and choices
 
 We prefer free/low-cost, state-of-the-art solutions. Always use latest stable versions and follow best practices.
 
@@ -126,7 +126,7 @@ We prefer free/low-cost, state-of-the-art solutions. Always use latest stable ve
 
 **Complete technology preferences:** [technology-preferences.md](./COLLABORATION/technology-preferences.md)
 
-## Development Standards
+## Development standards
 
 ### Pre-implementation checklist
 
@@ -171,9 +171,9 @@ Tests serve dual purposes: **Validation** (verify code works) and **Directional 
 
 **Complete testing guide:** [testing-strategy.md](../REFERENCE/testing-strategy.md)
 
-## Version Control and Repository Management
+## Version control and repository management
 
-### Repository Configuration
+### Repository configuration
 - If the project isn't in a git repo, stop and ask if we shouldn't initialize one first. Usually we do want to do this straight away so we don't risk losing any work.
 - Maintain README.md file and SPECIFICATIONS/OnePagerRequirements.md with project-specific details.
 - Use .gitignore for system files (.DS_Store, Thumbs.db, etc).
@@ -224,9 +224,9 @@ I value clean git history, but not at the expense of losing work or slowing down
 
 The goal is tracking our work and enabling collaboration, not perfect git aesthetics.
 
-## Claude Code Specific Guidelines
+## Claude Code specific guidelines
 
-### Tool Usage
+### Tool usage
 - Use concurrent tool calls when possible (batch independent operations)
 - Prefer Task tool for complex searches to reduce context usage
 - Use TodoWrite/TodoRead for task tracking and project visibility
@@ -235,14 +235,14 @@ The goal is tracking our work and enabling collaboration, not perfect git aesthe
 - Be concise in responses (aim for <4 lines unless detail requested)
 - Use `file_path:line_number` format when referencing code locations
 - Avoid unnecessary preamble or postamble
-- When you are using /compact, please focus on our conversation, your most recent (and most significant) learnings, and what you need to do next. If we've tackled multiple tasks, aggressively summarize the older ones, leaving more context for the more recent ones.
+- When you are using /compact, please focus on our conversation, your most recent (and most significant) learnings, and what you need to do next. If we've tackled multiple tasks, aggressively summarise the older ones, leaving more context for the more recent ones.
 
-### File Operations
+### File operations
 - Always prefer editing existing files over creating new ones
 - Use Read tool before Write/Edit operations
 - Check file structure and patterns before making changes
 
-### Learning and Memory Management
+### Learning and memory management
 - Use and update the project documentation frequently to capture technical insights, failed approaches, and user preferences.
 - Before starting complex tasks, search the project documentation for relevant past experiences and lessons learned.
 - Document architectural decisions and their outcomes for future reference.
@@ -255,24 +255,24 @@ The goal is tracking our work and enabling collaboration, not perfect git aesthe
   - Follow existing ADRs unless new information invalidates the reasoning
   - See [REFERENCE/decisions/CLAUDE.md](../REFERENCE/decisions/CLAUDE.md) for complete ADR guidance
 
-## Problem Solving and Debugging
+## Problem solving and debugging
 
 I value a scientific approach to debugging - let's understand what's actually happening before we start fixing things.
 
-### Core Debugging Mindset
+### Core debugging mindset
 - **Read the error messages first** - they're usually trying to tell us exactly what's wrong
 - **Look for root causes, not symptoms** - fixing the underlying issue prevents it from coming back
 - **One change at a time** - if we change multiple things, we won't know what actually worked
 - **Check what changed recently** - git diff and recent commits often point to the culprit
 - **Find working examples** - there's usually similar code in the project that works correctly
 
-### When Things Get Tricky
+### When things get tricky
 - **Say "I don't understand X"** rather than guessing - I'd rather help figure it out together
 - **Look for patterns** - is this breaking in similar ways elsewhere? Are we missing a dependency?
 - **Test your hypothesis** - make the smallest change possible to test one specific theory
 - **If the first fix doesn't work, stop and reassess** - piling on more fixes usually makes things worse
 
-### Practical Reality Check
+### Practical reality check
 Sometimes you need to move fast, sometimes the "proper" approach isn't practical. That's fine - just let me know when you're taking shortcuts so we can come back and clean things up later if needed. And as mentioned before, if accruing technical debt or planning to come back later and fix a shortcut, write it down in the project documentation so we don't forget.
 
 The goal is sustainable progress, not perfect process.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,6 +143,7 @@ We prefer free/low-cost, state-of-the-art solutions. Always use latest stable ve
 
 ### Writing code
 - **Follow the rules**: When submitting work, verify that your work is compliant with all our rules. (See also The First Rule!)
+- **Write tests alongside implementation** — tests are part of done, not a follow-up. See [testing-strategy.md](../REFERENCE/testing-strategy.md)
 - **Only build what is required**: Follow the YAGNI principle (You Aren't Gonna Need It).
 - **Prepare for the future**: While we want simple solutions that are fit for purpose and not more, design with flexibility and extensibility in mind. Remember that it's usually possible to add more extensibility later, but you can never take it away without introducing breaking changes.
 - **Use consistent style, always**: When modifying code, match the style and formatting of surrounding code, even if it differs from standard style guides. Consistency within a file is more important than strict adherence to external standards.
@@ -174,7 +175,7 @@ Tests serve dual purposes: **Validation** (verify code works) and **Directional 
 ## Version control and repository management
 
 ### Repository configuration
-- If the project isn't in a git repo, stop and ask if we shouldn't initialize one first. Usually we do want to do this straight away so we don't risk losing any work.
+- If the project isn't in a git repo, stop and ask if we shouldn't initialise one first. Usually we do want to do this straight away so we don't risk losing any work.
 - Maintain README.md file and SPECIFICATIONS/OnePagerRequirements.md with project-specific details.
 - Use .gitignore for system files (.DS_Store, Thumbs.db, etc).
 - Structure projects with clear separation of concerns.
@@ -221,6 +222,8 @@ I value clean git history, but not at the expense of losing work or slowing down
 - Include context about why the change was needed
 - Reference issues or requirements if relevant
 - Example: "Fix user login redirect after password reset - was sending users to 404 page"
+
+**Pull request reviews:** Always use `/review-pr` (regular PRs) or `/review-pr-team` (critical/architectural) — never review manually in the main session. See [pr-review-workflow.md](../REFERENCE/pr-review-workflow.md).
 
 The goal is tracking our work and enabling collaboration, not perfect git aesthetics.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,7 +25,7 @@
 - Please, PLEASE, call out bad ideas, unreasonable expectations, and mistakes - I depend on this, and will never fault you for it. You can be low-key, you can be direct.
 - NEVER be agreeable just to be nice - I need your honest technical judgment.
 - Hey, I'm Swedish. We don't beat around the bush, and we prefer frank discussions and progress over politeness and hesitation.
-- I really like jokes, and quirky oddball humor. But not when it gets in the way of the task at hand or confuses the work we are doing.
+- I really like jokes, and quirky oddball humour. But not when it gets in the way of the task at hand or confuses the work we are doing.
 
 ### Getting help and conflict resolution
 

--- a/.claude/COLLABORATION/CLAUDE.md
+++ b/.claude/COLLABORATION/CLAUDE.md
@@ -1,0 +1,7 @@
+# Collaboration guidance
+
+Navigation index for collaboration guidance files in this directory.
+
+- [documentation-standards.md](./documentation-standards.md) — Templates and process for writing project documentation
+- [product-management-mode.md](./product-management-mode.md) — PM partnership model, discovery workflow, and product thinking frameworks
+- [technology-preferences.md](./technology-preferences.md) — Technology stack recommendations and preferences

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "hooks": {},
   "permissions": {}
 }

--- a/REFERENCE/CLAUDE.md
+++ b/REFERENCE/CLAUDE.md
@@ -1,0 +1,16 @@
+# Reference documentation
+
+Navigation index for reference documentation in this directory. Auto-loads when working in REFERENCE/.
+
+- [DEVELOPMENT.md](./DEVELOPMENT.md) — Full development workflow, setup, commands, deployment
+- [ai-extraction-guide.md](./ai-extraction-guide.md) — How Claude extraction works
+- [claude_model_updates.md](./claude_model_updates.md) — Updating Claude API model versions
+- [environment-setup.md](./environment-setup.md) — Secrets and API key configuration
+- [geo-services-guide.md](./geo-services-guide.md) — Maps, geocoding, location search
+- [supabase-setup.md](./supabase-setup.md) — Database schema, auth, RLS policies
+- [technical-debt.md](./technical-debt.md) — Known limitations and deferred improvements
+- [testing-strategy.md](./testing-strategy.md) — Testing approach and coverage targets
+- [troubleshooting.md](./troubleshooting.md) — Common issues and solutions
+- [web-analytics.md](./web-analytics.md) — Analytics setup (planned)
+- [pr-review-workflow.md](./pr-review-workflow.md) — How to use `/review-pr` and `/review-pr-team` skills for code reviews
+- [decisions/](./decisions/) — Architecture Decision Records (ADRs) explaining why things are this way

--- a/REFERENCE/CLAUDE.md
+++ b/REFERENCE/CLAUDE.md
@@ -7,10 +7,10 @@ Navigation index for reference documentation in this directory. Auto-loads when 
 - [claude_model_updates.md](./claude_model_updates.md) — Updating Claude API model versions
 - [environment-setup.md](./environment-setup.md) — Secrets and API key configuration
 - [geo-services-guide.md](./geo-services-guide.md) — Maps, geocoding, location search
+- [pr-review-workflow.md](./pr-review-workflow.md) — How to use `/review-pr` and `/review-pr-team` skills for code reviews
 - [supabase-setup.md](./supabase-setup.md) — Database schema, auth, RLS policies
 - [technical-debt.md](./technical-debt.md) — Known limitations and deferred improvements
 - [testing-strategy.md](./testing-strategy.md) — Testing approach and coverage targets
 - [troubleshooting.md](./troubleshooting.md) — Common issues and solutions
 - [web-analytics.md](./web-analytics.md) — Analytics setup (planned)
-- [pr-review-workflow.md](./pr-review-workflow.md) — How to use `/review-pr` and `/review-pr-team` skills for code reviews
 - [decisions/](./decisions/) — Architecture Decision Records (ADRs) explaining why things are this way

--- a/REFERENCE/decisions/TEMPLATE-adr.md
+++ b/REFERENCE/decisions/TEMPLATE-adr.md
@@ -1,3 +1,5 @@
+> **Note:** This is an illustrative example ADR. The content (Next.js references, tsconfig.json, etc.) is fictional and project-specific — it exists to demonstrate format and depth, not to reflect this project's actual decisions.
+
 # ADR: Use TypeScript for All New Code
 
 **Date:** 2026-03-15

--- a/REFERENCE/pr-review-workflow.md
+++ b/REFERENCE/pr-review-workflow.md
@@ -80,17 +80,17 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 **The three reviewers:**
 
-**Security Specialist** 🛡️
+**Security Specialist**
 - Authentication, authorization, secrets
 - XSS, CSRF, SQL injection, input validation
 - Session security, dependency vulnerabilities
 
-**Product Manager** 📦
+**Product Manager**
 - Requirements alignment, UX
 - Edge cases, error handling, completeness
 - Documentation, backward compatibility
 
-**Senior Architect** 🏗️
+**Senior Architect**
 - Design patterns, code quality
 - Scalability, maintainability, testing
 - Technical debt, performance, architectural fit

--- a/REFERENCE/pr-review-workflow.md
+++ b/REFERENCE/pr-review-workflow.md
@@ -1,0 +1,265 @@
+# Pull Request Review Workflow
+
+**Related Documents:**
+- [Development Workflow](../CLAUDE.md#development-workflow)
+- [Testing Strategy](./testing-strategy.md)
+
+**Skills Available:**
+- `/review-pr` - Fast single-reviewer (1-2 min)
+- `/review-pr-team` - Collaborative multi-perspective (5-10 min)
+
+---
+
+## Overview
+
+This project uses automated PR review skills powered by agent teams. Reviews use fresh context (not biased by main session) and provide comprehensive, actionable feedback.
+
+---
+
+## Quick Reference
+
+### Use `/review-pr` for:
+✅ Regular implementation PRs
+✅ Quick sanity checks
+✅ Small, straightforward changes
+✅ Non-critical bug fixes
+✅ Documentation updates
+✅ When you want fast feedback
+
+**Time:** 1-2 minutes
+**Reviewer:** Single full-stack developer with fresh context
+**Model:** Sonnet (fast, capable)
+
+### Use `/review-pr-team` for:
+✅ Critical infrastructure changes
+✅ Security-sensitive features
+✅ Major architectural decisions
+✅ Complex multi-file changes
+✅ When multiple perspectives add real value
+✅ When you want thorough collaborative analysis
+
+**Time:** 5-10 minutes
+**Reviewers:** Security Specialist, Product Manager, Senior Architect (agent team with collaborative discussion)
+**Model:** Opus for all three reviewers (more thorough reasoning)
+
+---
+
+## How `/review-pr` Works
+
+**Fresh context approach:**
+1. Spawns independent subagent (not main session)
+2. Agent loads project context (CLAUDE.md, relevant specs)
+3. Reviews PR comprehensively across all dimensions
+4. Posts findings as PR comment
+
+**Review dimensions:**
+- Code quality (readability, naming, error handling)
+- Functionality (bugs, edge cases, correctness)
+- Security (vulnerabilities, secrets management)
+- Architecture & design (fit, patterns, extensibility)
+- Performance (optimization, caching, queries)
+- Testing (coverage, quality of tests)
+- TypeScript/types (type safety, proper usage)
+- Best practices (conventions, no deprecated patterns)
+
+**Output format:**
+- ✅ **Well Done** - What's good
+- 🔴 **Critical Issues** - Must fix (blocking)
+- ⚠️ **Suggestions** - Should consider (not blocking)
+- 💡 **Nice-to-Haves** - Optional improvements
+
+---
+
+## How `/review-pr-team` Works
+
+**Agent team collaboration:**
+1. Creates agent team with 3 specialized reviewers
+2. **Phase 1: Independent Review** - Each reviews from their perspective
+3. **Phase 2: Collaborative Discussion** - Reviewers debate, challenge, reach consensus
+4. Posts synthesized findings with discussion highlights
+
+**The three reviewers:**
+
+**Security Specialist** 🛡️
+- Authentication, authorization, secrets
+- XSS, CSRF, SQL injection, input validation
+- Session security, dependency vulnerabilities
+
+**Product Manager** 📦
+- Requirements alignment, UX
+- Edge cases, error handling, completeness
+- Documentation, backward compatibility
+
+**Senior Architect** 🏗️
+- Design patterns, code quality
+- Scalability, maintainability, testing
+- Technical debt, performance, architectural fit
+
+**Key difference from `/review-pr`:**
+- Reviewers **actually discuss** findings with each other
+- They **challenge** each other's severity assessments
+- They **debate** tradeoffs and propose solutions together
+- Lead synthesizes collaborative insights (not just 3 independent reports)
+
+**Output includes:**
+- Team consensus on critical issues
+- Documented disagreements (valuable signal)
+- Discussion highlights (how debate changed ratings)
+- Collaborative solutions that emerged
+
+---
+
+## Usage Examples
+
+### Running a Quick Review
+```bash
+# In your PR description or as a comment
+/review-pr 42
+```
+
+The skill will:
+1. Fetch PR #42 details
+2. Intelligently gather relevant context (CLAUDE.md, matching specs)
+3. Spawn fresh reviewer
+4. Post comprehensive review
+5. Provide summary with recommendation
+
+### Running Team Review
+```bash
+# For critical changes
+/review-pr-team 42
+```
+
+The skill will:
+1. Fetch PR #42 details
+2. Gather project context
+3. Create agent team (3 reviewers)
+4. Reviewers independently analyse
+5. Reviewers discuss and debate findings
+6. Lead synthesizes collaborative analysis
+7. Post unified review with discussion highlights
+8. Clean up team
+
+---
+
+## Best Practices
+
+### Before Requesting Review
+
+**Pre-commit checklist:**
+```bash
+npm test                  # All tests pass
+npx tsc --noEmit         # Type check passes
+git status               # Verify what's included
+git diff                 # Review your own changes first
+```
+
+**PR description should include:**
+- What changed and why
+- How to test manually (if needed)
+- Any deployment considerations
+- Links to relevant specs/issues
+
+### Interpreting Review Results
+
+**Critical Issues (🔴):**
+- Address before merging
+- These are blockers
+- Ask for clarification if needed
+
+**Suggestions (⚠️):**
+- Consider seriously
+- May address now or later
+- Not blocking merge
+
+**Nice-to-Haves (💡):**
+- Optional improvements
+- Consider for future work
+- Track in technical debt if deferred
+
+### Working with Team Reviews
+
+**If reviewers disagree:**
+- Both perspectives are valuable
+- Understand the tradeoffs
+- Make informed decision
+- Document your choice in PR
+
+**If discussion seems shallow:**
+- Reviewers might be too polite
+- You can ask them to "challenge each other more directly"
+- The debate phase surfaces better insights
+
+**Team consensus vs split:**
+- Unanimous agreement = high confidence
+- 2/3 agreement = strong signal
+- Split opinions = requires judgment call
+
+---
+
+## Integration with Development Workflow
+
+### Standard Workflow
+
+1. Create feature branch: `git checkout -b feature/feature-name`
+2. Check relevant specs in `SPECIFICATIONS/`
+3. Implement with tests: `npm test && npx tsc --noEmit`
+4. Create PR
+5. **Run `/review-pr`** for quick validation
+6. Address feedback
+7. Merge when approved
+
+### Critical Changes Workflow
+
+1. Create feature branch
+2. Review specs and architectural guidelines
+3. Consider using EnterPlanMode for complex features
+4. Implement with comprehensive tests
+5. Self-review: `git diff`, verify no secrets/debug code
+6. Create PR with detailed description
+7. **Run `/review-pr-team`** for multi-perspective analysis
+8. Reviewers discuss findings collaboratively
+9. Address critical issues and consensus concerns
+10. Document decisions on split opinions
+11. Merge when approved
+
+---
+
+## Troubleshooting
+
+### Review seems biased or incomplete
+- Skills spawn fresh agents (not main session)
+- If context seems wrong, check that relevant specs are in SPECIFICATIONS/
+- Skills auto-discover specs by keywords from PR
+
+### Team reviewers not discussing
+- Tell them: "Share findings via broadcast and debate severity"
+- Check Phase 1 is complete before expecting Phase 2
+- If too polite: "Challenge each other's assumptions more directly"
+
+### Review posted but nothing seems wrong
+- Green light is valuable signal
+- Check "Well Done" section for validation
+- Proceed with confidence
+
+### Want more detail on specific issue
+- Ask reviewer directly (they're still in context)
+- Request specific analysis: "Expand on the XSS concern"
+
+---
+
+## Sub-agent architecture
+
+Reviewer agents are defined as named sub-agents in `.claude/agents/` using YAML frontmatter. Each agent file registers a persona, toolset, and model — the skill invokes them by name.
+
+**Agent definitions:**
+- `code-reviewer.md` — used by `/review-pr` (Sonnet)
+- `security-specialist.md` — used by `/review-pr-team` (Opus)
+- `product-reviewer.md` — used by `/review-pr-team` (Opus)
+- `architect-reviewer.md` — used by `/review-pr-team` (Opus)
+
+**Why separate files?** Agent definitions are reusable and evolvable independently from skill orchestration logic. Update reviewer behaviour once; all skills that use it benefit automatically.
+
+---
+
+**Note:** These skills use intelligent context discovery - they automatically find and read relevant SPECIFICATIONS/ files based on PR keywords. Keep specs up-to-date for best results.

--- a/REFERENCE/pr-review-workflow.md
+++ b/REFERENCE/pr-review-workflow.md
@@ -2,7 +2,7 @@
 
 **Related Documents:**
 - [Development workflow](../CLAUDE.md#development-commands)
-- [Testing Strategy](./testing-strategy.md)
+- [Testing strategy](./testing-strategy.md)
 
 **Skills Available:**
 - `/review-pr` - Fast single-reviewer (1-2 min)
@@ -57,7 +57,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 - Functionality (bugs, edge cases, correctness)
 - Security (vulnerabilities, secrets management)
 - Architecture & design (fit, patterns, extensibility)
-- Performance (optimization, caching, queries)
+- Performance (optimisation, caching, queries)
 - Testing (coverage, quality of tests)
 - TypeScript/types (type safety, proper usage)
 - Best practices (conventions, no deprecated patterns)
@@ -76,7 +76,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 1. Creates agent team with 3 specialized reviewers
 2. **Phase 1: Independent Review** - Each reviews from their perspective
 3. **Phase 2: Collaborative Discussion** - Reviewers debate, challenge, reach consensus
-4. Posts synthesized findings with discussion highlights
+4. Posts synthesised findings with discussion highlights
 
 **The three reviewers:**
 
@@ -99,7 +99,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 - Reviewers **actually discuss** findings with each other
 - They **challenge** each other's severity assessments
 - They **debate** tradeoffs and propose solutions together
-- Lead synthesizes collaborative insights (not just 3 independent reports)
+- Lead synthesises collaborative insights (not just 3 independent reports)
 
 **Output includes:**
 - Team consensus on critical issues
@@ -136,7 +136,7 @@ The skill will:
 3. Create agent team (3 reviewers)
 4. Reviewers independently analyse
 5. Reviewers discuss and debate findings
-6. Lead synthesizes collaborative analysis
+6. Lead synthesises collaborative analysis
 7. Post unified review with discussion highlights
 8. Clean up team
 
@@ -214,13 +214,13 @@ git diff                 # Review your own changes first
 1. Create feature branch
 2. Review specs and architectural guidelines
 3. Implement with comprehensive tests
-5. Self-review: `git diff`, verify no secrets/debug code
-6. Create PR with detailed description
-7. **Run `/review-pr-team`** for multi-perspective analysis
-8. Reviewers discuss findings collaboratively
-9. Address critical issues and consensus concerns
-10. Document decisions on split opinions
-11. Merge when approved
+4. Self-review: `git diff`, verify no secrets/debug code
+5. Create PR with detailed description
+6. **Run `/review-pr-team`** for multi-perspective analysis
+7. Reviewers discuss findings collaboratively
+8. Address critical issues and consensus concerns
+9. Document decisions on split opinions
+10. Merge when approved
 
 ---
 

--- a/REFERENCE/pr-review-workflow.md
+++ b/REFERENCE/pr-review-workflow.md
@@ -1,7 +1,7 @@
-# Pull Request Review Workflow
+# Pull request review workflow
 
 **Related Documents:**
-- [Development Workflow](../CLAUDE.md#development-workflow)
+- [Development workflow](../CLAUDE.md#development-commands)
 - [Testing Strategy](./testing-strategy.md)
 
 **Skills Available:**
@@ -16,7 +16,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 ---
 
-## Quick Reference
+## Quick reference
 
 ### Use `/review-pr` for:
 ✅ Regular implementation PRs
@@ -44,7 +44,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 ---
 
-## How `/review-pr` Works
+## How `/review-pr` works
 
 **Fresh context approach:**
 1. Spawns independent subagent (not main session)
@@ -70,7 +70,7 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 ---
 
-## How `/review-pr-team` Works
+## How `/review-pr-team` works
 
 **Agent team collaboration:**
 1. Creates agent team with 3 specialized reviewers
@@ -109,9 +109,9 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 ---
 
-## Usage Examples
+## Usage examples
 
-### Running a Quick Review
+### Running a quick review
 ```bash
 # In your PR description or as a comment
 /review-pr 42
@@ -124,7 +124,7 @@ The skill will:
 4. Post comprehensive review
 5. Provide summary with recommendation
 
-### Running Team Review
+### Running team review
 ```bash
 # For critical changes
 /review-pr-team 42
@@ -142,9 +142,9 @@ The skill will:
 
 ---
 
-## Best Practices
+## Best practices
 
-### Before Requesting Review
+### Before requesting review
 
 **Pre-commit checklist:**
 ```bash
@@ -160,7 +160,7 @@ git diff                 # Review your own changes first
 - Any deployment considerations
 - Links to relevant specs/issues
 
-### Interpreting Review Results
+### Interpreting review results
 
 **Critical Issues (🔴):**
 - Address before merging
@@ -177,7 +177,7 @@ git diff                 # Review your own changes first
 - Consider for future work
 - Track in technical debt if deferred
 
-### Working with Team Reviews
+### Working with team reviews
 
 **If reviewers disagree:**
 - Both perspectives are valuable
@@ -197,9 +197,9 @@ git diff                 # Review your own changes first
 
 ---
 
-## Integration with Development Workflow
+## Integration with development workflow
 
-### Standard Workflow
+### Standard workflow
 
 1. Create feature branch: `git checkout -b feature/feature-name`
 2. Check relevant specs in `SPECIFICATIONS/`
@@ -209,12 +209,11 @@ git diff                 # Review your own changes first
 6. Address feedback
 7. Merge when approved
 
-### Critical Changes Workflow
+### Critical changes workflow
 
 1. Create feature branch
 2. Review specs and architectural guidelines
-3. Consider using EnterPlanMode for complex features
-4. Implement with comprehensive tests
+3. Implement with comprehensive tests
 5. Self-review: `git diff`, verify no secrets/debug code
 6. Create PR with detailed description
 7. **Run `/review-pr-team`** for multi-perspective analysis


### PR DESCRIPTION
## Summary

- Adds clear branch protection guardrails to `.claude/CLAUDE.md` (NEVER push to main, Pre-implementation checklist, CRITICAL git block)
- Replaces scattered Feature Development Checklist with a tight 3-part Completion Requirements definition of done
- Trims verbose Testing Strategy section to 6 lines, pointing to `REFERENCE/testing-strategy.md`
- Adds British English and headline capitalisation rules to Documentation Standards
- Creates `REFERENCE/CLAUDE.md` and `.claude/COLLABORATION/CLAUDE.md` as lazy-loading nav indexes
- Adds clarifying note to `REFERENCE/decisions/TEMPLATE-adr.md`

## Test plan

- [ ] Review `.claude/CLAUDE.md` for coherence and completeness
- [ ] Verify `REFERENCE/CLAUDE.md` lists all files in REFERENCE/
- [ ] Verify `.claude/COLLABORATION/CLAUDE.md` lists all files in COLLABORATION/
- [ ] Confirm no project-specific documentation was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)