### PR TITLE
Fix CF Access login redirect URL

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,12 +30,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signIn = () => {
-    window.location.href = `/cdn-cgi/access/login?redirect_url=${encodeURIComponent(window.location.href)}`;
+    // CF Access login is served from the team domain, not the app domain.
+    // This sets the CF-Authorization cookie for the app, then redirects back.
+    const teamDomain = 'https://herrings.cloudflareaccess.com';
+    window.location.href = `${teamDomain}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(window.location.href)}`;
   };
 
   const signOut = () => {
     setUser(null);
-    window.location.href = '/cdn-cgi/access/logout';
+    window.location.href = 'https://herrings.cloudflareaccess.com/cdn-cgi/access/logout';
   };
 
   return (


### PR DESCRIPTION
## Summary

- The `signIn()` redirect was pointing to `/cdn-cgi/access/login` on the app domain, which only works when CF Access enforces auth at the edge. Our setup validates JWTs server-side in the Worker but doesn't enforce at the edge, so the login/logout redirects must go to the CF team domain (`herrings.cloudflareaccess.com`) instead.

## Test plan

- [ ] Click "Sign in with Google" — should redirect to Google OAuth via Cloudflare Access
- [ ] After login, admin controls should appear
- [ ] Sign out should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)