### PR TITLE
Wire up /auth/login as CF Access login trigger

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,7 +30,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signIn = () => {
-    window.location.href = `/cdn-cgi/access/login?redirect_url=${encodeURIComponent(window.location.href)}`;
+    // Navigate to /auth/login — CF Access enforces auth on this path,
+    // completes Google OAuth, sets the CF-Authorization cookie, then redirects
+    // back to /auth/login where the Worker redirects to /.
+    window.location.href = '/auth/login';
   };
 
   const signOut = () => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1024,6 +1024,13 @@ export default {
       return newResponse;
     }
     
+    // GET /auth/login — CF Access login trigger
+    // CF Access enforces auth on this path, sets the CF-Authorization cookie,
+    // then redirects here. The Worker redirects to / so the user lands on the homepage.
+    if (url.pathname === '/auth/login' && request.method === 'GET') {
+      return Response.redirect(`${url.origin}/`, 302);
+    }
+
     // --- D1 Data API routes ---
 
     // GET /api/restaurants — all restaurants with locations and optional filters (public)


### PR DESCRIPTION
## Summary

- CF Access now enforces auth on `/auth/login` (configured in Zero Trust dashboard)
- `signIn()` navigates to `/auth/login` → CF Access does Google OAuth → sets cookie → redirects back → Worker sends user to `/`
- `signOut()` uses `/cdn-cgi/access/logout` (works now that CF Access is active on the domain)
- Worker: added `GET /auth/login` handler that 302 redirects to `/`

## Test plan

- [ ] Click "Sign in with Google" → should redirect to Google OAuth
- [ ] After auth, land back on homepage with admin controls visible
- [ ] Sign out should clear the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)