### PR TITLE
Fix CF Access cookie name (underscore not hyphen)

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -875,7 +875,7 @@ function parseRestaurant(row) {
 
 function getCFToken(request) {
   const cookie = request.headers.get('Cookie') || '';
-  const match = cookie.match(/CF-Authorization=([^;]+)/);
+  const match = cookie.match(/CF_Authorization=([^;]+)/);
   return match ? match[1] : null;
 }
 


### PR DESCRIPTION
CF Access sets `CF_Authorization` (underscore). Worker was matching `CF-Authorization` (hyphen). One-line fix.