### PR TITLE
Post-migration cleanup: remove Supabase, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Model versions are centralized in `src/config/claude.ts`. When Anthropic depreca
 
 ### Tech Stack
 - **Frontend**: React 18 + TypeScript + Vite + Tailwind CSS + shadcn/ui
-- **Backend**: Supabase (PostgreSQL) + Cloudflare Workers
+- **Backend**: Cloudflare D1 (SQLite) + Cloudflare Workers
+- **Auth**: Cloudflare Access + Google OAuth (JWT verified server-side in Worker)
 - **AI**: Claude Sonnet 4.5 for restaurant extraction and review summarization
 - **Maps**: Mapbox GL JS with clustering
 - **Geo**: Google Maps Geocoding and Places APIs
@@ -94,7 +95,7 @@ interface RestaurantAddress {
 - `src/components/InteractiveMap.tsx` - Mapbox map with clustering
 
 ### Services
-- `src/services/restaurants.ts` - Supabase CRUD operations
+- `src/services/restaurants.ts` - Restaurant CRUD via Worker API
 - `src/services/claudeExtractor.ts` - AI restaurant extraction
 - `src/services/reviewEnrichmentService.ts` - Google Reviews + Claude summarization
 - `src/services/smartGeoSearch.ts` - Three-tier geo search
@@ -115,9 +116,11 @@ interface RestaurantAddress {
 The build process auto-syncs Worker asset references via `scripts/update-worker-assets.js`. This prevents MIME type errors on deployment.
 
 ### Admin Authentication
-- Magic link auth via Supabase
+- Cloudflare Access + Google OAuth (no password, no magic links)
+- Login: navigate to `/auth/login` → Google OAuth → CF-Authorization cookie set
+- JWT verified server-side in Worker via `verifyCFAccessJWT()` (RS256 + JWKS)
+- Authorized email checked in Worker: `AUTHORIZED_ADMIN_EMAIL` in wrangler.toml
 - Admin controls (edit/delete/rate) hidden from unauthenticated users
-- Authorized email: magnus.hultberg@gmail.com
 
 ## Documentation
 
@@ -127,7 +130,8 @@ The build process auto-syncs Worker asset references via `scripts/update-worker-
 
 - `REFERENCE/DEVELOPMENT.md` - **Full development workflow** (setup, commands, deployment)
 - `REFERENCE/environment-setup.md` - Secrets and API key configuration
-- `REFERENCE/supabase-setup.md` - Database schema, auth, RLS policies
+- `REFERENCE/supabase-setup.md` - Legacy: Supabase setup (migrated to D1 — see `SPECIFICATIONS/d1-migration.md`)
+- `REFERENCE/d1-setup.md` - D1 database schema and Worker API (TODO: create)
 - `REFERENCE/ai-extraction-guide.md` - How Claude extraction works
 - `REFERENCE/geo-services-guide.md` - Maps, geocoding, location search
 - `REFERENCE/claude_model_updates.md` - Updating Claude API model versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.56.1",
         "@tanstack/react-query": "^5.83.0",
         "@types/mapbox-gl": "^3.4.1",
         "class-variance-authority": "^0.7.1",
@@ -4022,80 +4021,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.71.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
-      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
-      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
-      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.4.tgz",
-      "integrity": "sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.13",
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "ws": "^8.18.2"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
-      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.56.1.tgz",
-      "integrity": "sha512-cb/kS0d6G/qbcmUFItkqVrQbxQHWXzfRZuoiSDv/QiU6RbGNTn73XjjvmbBCZ4MMHs+5teihjhpEVluqbXISEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.5",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.21.3",
-        "@supabase/realtime-js": "2.15.4",
-        "@supabase/storage-js": "^2.10.4"
-      }
-    },
     "node_modules/@swc/core": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.2.tgz",
@@ -4604,6 +4529,7 @@
       "version": "22.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4613,12 +4539,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -4656,15 +4576,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -10176,12 +10087,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -10293,6 +10198,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -10679,12 +10585,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -10693,16 +10593,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -11369,27 +11259,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.56.1",
     "@tanstack/react-query": "^5.83.0",
     "@types/mapbox-gl": "^3.4.1",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Remove `@supabase/supabase-js` (no longer used) and update CLAUDE.md to reflect the D1 + CF Access architecture.