### PR TITLE
Chore: allowlist bare task-runner invocations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,16 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "hooks": {},
-  "permissions": {}
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "Bash(npx tsc --noEmit)",
+      "Bash(bun run test)",
+      "Bash(bun run typecheck)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run lint)",
+      "Bash(npm run build)",
+      "Bash(npm run dev)"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Adds 8 exact-form Bash allowlist entries to `.claude/settings.json` for the read-only validation commands we run most often: `npm test`, `npx tsc --noEmit`, `npm run typecheck/lint/build/dev`, `bun run test/typecheck`
- Exact-form only — no wildcards. Wildcarding interpreters or package runners (`npm run *`, `npx *`, `bun run *`) would grant arbitrary code execution and is explicitly disallowed by the `fewer-permission-prompts` skill's rules
- Generated via `/fewer-permission-prompts` skill after scanning the 50 most recent session transcripts

## Practical effect
Modest. Most actual invocations include redirects/pipes (`2>&1 | tail`) that do not match the exact forms. Small win for the occasional clean bare invocation.

## Test plan
- [x] Valid JSON (file loads without syntax error)
- [ ] Next session confirms the bare invocations no longer prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)