### PR TITLE
Chore: allowlist npm run test:coverage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,8 @@
       "Bash(npm run typecheck)",
       "Bash(npm run lint)",
       "Bash(npm run build)",
-      "Bash(npm run dev)"
+      "Bash(npm run dev)",
+      "Bash(npm run test:coverage)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- One additional exact-form entry identified by a re-run of the `/fewer-permission-prompts` skill: `Bash(npm run test:coverage)` (10 hits in recent transcripts)
- Named npm script; exact-form is explicitly permitted per the skill's rules (wildcards on package runners remain forbidden)

## Test plan
- [x] Valid JSON
- [ ] Confirm in next session that `npm run test:coverage` no longer prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)