### PR TITLE
Update Cloudflare Web Analytics beacon token

### DIFF
--- a/REFERENCE/web-analytics.md
+++ b/REFERENCE/web-analytics.md
@@ -9,7 +9,7 @@
 ## Cloudflare Web Analytics
 
 **Implementation:** Production (restaurants.hultberg.org)
-**Token:** `f71c3c28b82c4c6991ec3d41b7f1496f`
+**Token:** `0cccf50cbccc4919ab5984eb8602ca65`
 
 ### Features
 
@@ -27,7 +27,7 @@
 ```html
 <!-- Cloudflare Web Analytics -->
 <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
-        data-cf-beacon='{"token": "f71c3c28b82c4c6991ec3d41b7f1496f"}'></script>
+        data-cf-beacon='{"token": "0cccf50cbccc4919ab5984eb8602ca65"}'></script>
 <!-- End Cloudflare Web Analytics -->
 ```
 
@@ -198,7 +198,7 @@ curl -I https://static.cloudflareinsights.com/beacon.min.js
 
 # Check token in HTML
 curl https://restaurants.hultberg.org | grep "data-cf-beacon"
-# Should show: {"token": "f71c3c28b82c4c6991ec3d41b7f1496f"}
+# Should show: {"token": "0cccf50cbccc4919ab5984eb8602ca65"}
 ```
 
 ### Script not loading in development

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <meta property="og:image" content="" />
 
         <!-- Cloudflare Web Analytics -->
-        <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "f71c3c28b82c4c6991ec3d41b7f1496f"}'></script>
+        <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "0cccf50cbccc4919ab5984eb8602ca65"}'></script>
         <!-- End Cloudflare Web Analytics -->
     </head>
 


### PR DESCRIPTION
## Summary
- Replace the stale Cloudflare Web Analytics token in `index.html` with the current token for restaurants.hultberg.org
- The previous token (`f71c3c28...`) appeared to be stale; the new token (`0cccf50c...`) was provided by Magnus after creating/locating the correct RUM site in Cloudflare
- This is an SPA, so the single beacon script in `index.html` covers all client-side routes

## Test plan
- [ ] Merge and wait for GitHub Actions deploy
- [ ] Visit restaurants.hultberg.org, navigate a couple of routes
- [ ] Confirm requests to `static.cloudflareinsights.com/beacon.min.js` fire in DevTools Network tab
- [ ] Check Cloudflare dashboard → Web Analytics → site shows incoming page views within ~30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)