### PR TITLE
Fix About page tech stack - replace Supabase with Cloudflare D1

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -250,8 +250,8 @@ const About = () => {
                 <div>
                   <h4 className="font-medium mb-2">Backend</h4>
                   <ul className="space-y-1 text-muted-foreground">
-                    <li>CloudFlare Workers</li>
-                    <li>Supabase PostgreSQL</li>
+                    <li>Cloudflare Workers</li>
+                    <li>Cloudflare D1 (SQLite)</li>
                     <li>Claude API</li>
                     <li>Google Maps API</li>
                   </ul>


### PR DESCRIPTION
## Summary
- Replace outdated "Supabase PostgreSQL" entry in the About page Backend section with "Cloudflare D1 (SQLite)" to match the current architecture
- Normalise "CloudFlare" → "Cloudflare" to match the official brand spelling

## Context
We migrated off Supabase to Cloudflare D1 some time ago (see `REFERENCE/ARCHIVE/supabase-setup.md`) but the About page copy at https://restaurants.hultberg.org/about still advertised the old stack.

## Test plan
- [ ] Visit `/about` in dev and confirm the Backend box shows: Cloudflare Workers, Cloudflare D1 (SQLite), Claude API, Google Maps API
- [ ] Verify no other Supabase mentions have crept into the About page

## Follow-up (out of scope)
There are three other stale Supabase references in `src/` (comments in `Index.tsx`, `worker.js`, and a disconnected-state message in `MapView.tsx`). Worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)