### PR TITLE
Add CF Analytics beacon to Worker SPA fallback HTML

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1328,6 +1328,10 @@ export default {
         />
         <meta property="og:type" content="website" />
         <meta property="og:image" content="" />
+
+        <!-- Cloudflare Web Analytics -->
+        <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "0cccf50cbccc4919ab5984eb8602ca65"}'></script>
+        <!-- End Cloudflare Web Analytics -->
       <!-- ASSET_PLACEHOLDER_SCRIPT -->
       <!-- ASSET_PLACEHOLDER_CSS -->
     </head>


### PR DESCRIPTION
## Summary
The Cloudflare Web Analytics beacon was only firing on root (\`/\`) requests, not on deep routes like \`/about\`. Root cause: the Worker's hand-rolled SPA fallback at \`src/worker.js:1309\` embeds its own copy of \`index.html\` as a string literal, and that copy was missing the analytics \`<script>\` tag. So any direct / hard-loaded request to a non-root path got HTML with no beacon.

This one-line fix adds the beacon tag to the Worker's embedded HTML so it mirrors \`index.html\`.

Correction to my earlier suggestion that we might need \`"spa": true\` in the beacon config — per [Cloudflare's official docs](https://developers.cloudflare.com/web-analytics/faq/), the beacon **auto-tracks SPA route changes** once it's present on the page. No React Router hook required. So simply getting the beacon onto every served page is sufficient.

## Verification
Before the fix:
\`\`\`
$ curl -s https://restaurants.hultberg.org/about | grep cloudflareinsights
# (no output — beacon missing)
$ curl -s https://restaurants.hultberg.org/ | grep cloudflareinsights
<script defer src='https://static.cloudflareinsights.com/beacon.min.js' ...>
\`\`\`
After the fix (locally rebuilt worker has the beacon):
\`\`\`
$ grep -c cloudflareinsights dist/wandering_paths_record/worker.js
1
\`\`\`

## Checks
- [x] \`npm test\` — 159/159 passing
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run build\` — beacon present in built worker

## Follow-up candidate (separate PR)
The embedded HTML in \`src/worker.js\` duplicates the real \`index.html\` and silently drifts whenever \`index.html\` changes (that's exactly how we got here — PR #20 updated the beacon token in \`index.html\` but not in the Worker). Two clean options:
1. Extend \`scripts/update-worker-assets.js\` to swap in the full \`dist/client/index.html\` content, not just the two asset placeholder lines
2. Switch to wrangler's native \`not_found_handling = "single-page-application"\` in \`[assets]\` — would delete the hand-rolled fallback entirely. Needs care around \`/api/*\` routes so they still hit the Worker, not the SPA fallback

I'll open an issue for this after merge unless you'd rather tackle it now.

## Test plan
- [ ] After deploy, hard-refresh \`https://restaurants.hultberg.org/about\` and verify \`beacon.min.js\` fires in the Network tab
- [ ] Click between List / About / a restaurant detail page from inside the app and verify each triggers a beacon fire (the beacon auto-handles pushState)

🤖 Generated with [Claude Code](https://claude.com/claude-code)