### PR TITLE
Fix post-rollout consistency gaps (sweep findings)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -17,7 +17,7 @@ This skill reviews a PR at the right level of depth — not too shallow, not tok
 |---|---|---|---|
 | **light** | `light-reviewer` (narrow sanity check) + `technical-writer` (temporal-language + REFERENCE/ currency) | Docs, tests, styling, comment-only changes | ~1–2 min |
 | **standard** | `code-reviewer` (full default prompt) + `technical-writer` | Typical feature work, core logic, utilities | ~2–4 min |
-| **team** | Multi-perspective team (security, product, architect, docs) with debate | Data layer (Supabase migrations, RLS), auth, CI, dependencies, secrets | ~2–7 min |
+| **team** | Multi-perspective team (security, product, architect, docs) with debate | Data layer (D1 migrations, wrangler.toml), auth, CI, dependencies, secrets | ~2–7 min |
 
 Team is auto-selected when the change touches high-blast-radius paths. You can always force team directly with `/review-pr-team N`.
 

--- a/REFERENCE/CLAUDE.md
+++ b/REFERENCE/CLAUDE.md
@@ -10,6 +10,7 @@ Navigation index for reference documentation in this directory. Auto-loads when 
 - [geo-services-guide.md](./geo-services-guide.md) — Maps, geocoding, location search
 - [claude_model_updates.md](./claude_model_updates.md) — Updating Claude API model versions
 - [pr-review-workflow.md](./pr-review-workflow.md) — How to use `/review-pr` and `/review-pr-team` skills for code reviews
+- [scratch-write-hook.md](./scratch-write-hook.md) — SCRATCH/ write hook: how it works, verification, extension, removal
 - [technical-debt.md](./technical-debt.md) — Known limitations and deferred improvements
 - [testing-strategy.md](./testing-strategy.md) — Testing approach and coverage targets
 - [troubleshooting.md](./troubleshooting.md) — Common issues and solutions

--- a/REFERENCE/scratch-write-hook.md
+++ b/REFERENCE/scratch-write-hook.md
@@ -1,0 +1,63 @@
+# SCRATCH write hook — operations guide
+
+The `approve-scratch-write.sh` PreToolUse hook auto-approves `Write` tool calls into `<project>/SCRATCH/`. This is a workaround for an upstream Claude Code defect where `Write(/SCRATCH/*)` allow-list entries are not honoured in fresh sessions.
+
+**For the decision record and the 5 sightings that established the defect:** see [`REFERENCE/decisions/2026-04-26-scratch-write-pretooluse-hook.md`](./decisions/2026-04-26-scratch-write-pretooluse-hook.md).
+
+---
+
+## How it works
+
+The hook is registered in `.claude/settings.json` under `hooks.PreToolUse` with a `Write` matcher. On every `Write` tool call, Claude Code spawns the hook before the permission gating layer. The hook:
+
+1. Reads the `file_path` argument from the tool input JSON via `parse-tool-input.sh`.
+2. Rejects the call (exits 0 without emitting `allow`) if `CLAUDE_PROJECT_DIR` is not set, if the path contains `..`, or if the path does not begin with `$CLAUDE_PROJECT_DIR/SCRATCH/`.
+3. Emits `{"hookSpecificOutput": {"permissionDecision": "allow", "reason": "..."}}` for paths that pass.
+
+Emitting `allow` bypasses the permission prompt entirely. Exits without emitting anything for all other `Write` calls — they proceed through normal gating.
+
+---
+
+## Verifying the hook is working
+
+Run the test suite:
+
+```bash
+.claude/hooks/tests/approve-scratch-write/run-tests.sh
+```
+
+Expected: `Tests: 7/7 passing`.
+
+To manually confirm in a session: open a fresh Claude Code session and write any file to `SCRATCH/`. The write should complete without a permission prompt.
+
+---
+
+## Extending — adding paths or rules
+
+The hook is intentionally conservative: only `SCRATCH/` is auto-approved. If you need to auto-approve writes to a different directory:
+
+1. Either extend the hook to check additional paths (update the guard in `approve-scratch-write.sh` and add corresponding test fixtures).
+2. Or create a second hook file, register it under `hooks.PreToolUse` in `settings.json`, and add its test suite.
+
+Do not broaden the existing hook to cover arbitrary paths — the path specificity is the point.
+
+---
+
+## Removing the hook
+
+If the upstream Claude Code defect is fixed (i.e. `Write(/SCRATCH/*)` allow-list entries are reliably honoured in fresh sessions), the hook can be removed:
+
+1. Verify the fix by adding only `"Write(/SCRATCH/*)"` to the `allow` array in `settings.json`, removing the hook registration from `hooks.PreToolUse`, and confirming writes to `SCRATCH/` are silenced without prompts in a fresh session.
+2. If confirmed: remove the hook registration from `settings.json`, delete `.claude/hooks/approve-scratch-write.sh`, and delete `.claude/hooks/tests/approve-scratch-write/`.
+3. Restore the `Read(/SCRATCH/*)` entries (they work correctly — only `Write` was broken).
+4. Update the ADR at `REFERENCE/decisions/2026-04-26-scratch-write-pretooluse-hook.md` to mark Status as Superseded and document the Claude Code version where the fix landed.
+
+---
+
+## Related files
+
+- Hook: `.claude/hooks/approve-scratch-write.sh`
+- Shared library: `.claude/hooks/lib/parse-tool-input.sh`
+- Test suite: `.claude/hooks/tests/approve-scratch-write/run-tests.sh`
+- Settings registration: `.claude/settings.json` → `hooks.PreToolUse`
+- Decision record: `REFERENCE/decisions/2026-04-26-scratch-write-pretooluse-hook.md`

--- a/REFERENCE/scratch-write-hook.md
+++ b/REFERENCE/scratch-write-hook.md
@@ -26,7 +26,7 @@ Run the test suite:
 .claude/hooks/tests/approve-scratch-write/run-tests.sh
 ```
 
-Expected: `Tests: 7/7 passing`.
+Expected: `Tests: 7/7 passing` (6 fixture-based cases plus the executability guard).
 
 To manually confirm in a session: open a fresh Claude Code session and write any file to `SCRATCH/`. The write should complete without a permission prompt.
 
@@ -49,7 +49,7 @@ If the upstream Claude Code defect is fixed (i.e. `Write(/SCRATCH/*)` allow-list
 
 1. Verify the fix by adding only `"Write(/SCRATCH/*)"` to the `allow` array in `settings.json`, removing the hook registration from `hooks.PreToolUse`, and confirming writes to `SCRATCH/` are silenced without prompts in a fresh session.
 2. If confirmed: remove the hook registration from `settings.json`, delete `.claude/hooks/approve-scratch-write.sh`, and delete `.claude/hooks/tests/approve-scratch-write/`.
-3. Restore the `Read(/SCRATCH/*)` entries (they work correctly — only `Write` was broken).
+3. Do not remove the `Read(/SCRATCH/*)` entries — they work correctly and were never part of the hook workaround; only `Write` was broken.
 4. Update the ADR at `REFERENCE/decisions/2026-04-26-scratch-write-pretooluse-hook.md` to mark Status as Superseded and document the Claude Code version where the fix landed.
 
 ---

--- a/SPECIFICATIONS/CLAUDE.md
+++ b/SPECIFICATIONS/CLAUDE.md
@@ -4,10 +4,6 @@ Auto-loaded when working with files in this directory. Forward-looking plans for
 
 ---
 
-**⚠️ TEMPLATE GUIDANCE** - This file explains how to use this folder. When starting a new project, update this file to list your actual implementation phases.
-
----
-
 ## Purpose of this folder
 
 The SPECIFICATIONS folder contains **forward-looking plans** for features you're actively building. These are living documents that guide development and evolve as you learn more.


### PR DESCRIPTION
## Summary

- **Create `REFERENCE/scratch-write-hook.md`** — the missing operations doc for the SCRATCH write hook. Referenced in `approve-scratch-write.sh` and `settings.json` but never written. Covers: how the hook works, how to verify it, how to extend it, and the removal procedure if the upstream Claude Code defect is fixed.
- **Index it in `REFERENCE/CLAUDE.md`** so it's discoverable alongside the other reference docs.
- **Remove stale ⚠️ TEMPLATE GUIDANCE banner** from `SPECIFICATIONS/CLAUDE.md` — content had already been project-customised; banner was cosmetic noise left over from the template.
- **Update `review-pr/SKILL.md` team-tier description** from "Supabase migrations, RLS" to "D1 migrations, wrangler.toml" — this project uses D1; the triage logic in `triage-reviewer.md` was already correct, just the user-facing description table was stale.

Findings from the 9-area post-rollout consistency sweep run after Packets 1 + 2 merged. No functional changes — all three fixes are documentation/description corrections.

## Test plan

- [ ] `REFERENCE/scratch-write-hook.md` exists and all links within it resolve (ADR, hook file paths)
- [ ] `REFERENCE/CLAUDE.md` index includes the new entry
- [ ] `SPECIFICATIONS/CLAUDE.md` opens without the template banner
- [ ] `review-pr/SKILL.md` line 20 reads "D1 migrations, wrangler.toml"
- [ ] Both hook test suites still pass: `40/40` and `7/7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)