### PR TITLE
Add Food cart and Hole-in-the-wall venue types

### DIFF
--- a/.claude/project-config.json
+++ b/.claude/project-config.json
@@ -1,5 +1,5 @@
 {
-  "prReviewMode": "prompt-on-first-use",
+  "prReviewMode": "enabled",
 
   "_meta": {
     "description": "Project-level configuration for template features. Checked in to git so team members share the same settings. For the canonical gate logic and schema, see '.claude/skills/review-gate.md'. For a user-facing overview and the local-override pattern, see '.claude/CLAUDE.md' → 'Automated PR review system' and 'REFERENCE/pr-review-workflow.md' → 'Configuration'.",

--- a/REFERENCE/ai-extraction-guide.md
+++ b/REFERENCE/ai-extraction-guide.md
@@ -165,7 +165,7 @@ export const CLAUDE_MAX_TOKENS = {
 | `cuisinePrimary` | enum | ✅ | Primary cuisine category |
 | `cuisineSecondary` | enum | | Secondary for fusion only |
 | `style` | enum | ✅ | Traditional/Modern/Fusion/etc. |
-| `venue` | enum | ✅ | Restaurant/Cafe/Pub/Bar/Bakery |
+| `venue` | enum | ✅ | Restaurant/Cafe/Pub/Bar/Bakery/Food Cart/Hole-in-the-Wall |
 | `description` | string | | 2-3 sentence summary |
 | `dietaryOptions` | string | | Cooking style, ingredients |
 | `priceRange` | enum | | $/$$/$$$/$$$$ |
@@ -199,6 +199,8 @@ Martian (only if truly unclassifiable)
 - `Pub` - British pub
 - `Bar` - Drinks-focused
 - `Bakery` - Bakery with dining
+- `Food Cart` - Street-side cart or stall
+- `Hole-in-the-Wall` - Tiny, informal spot with minimal decor
 
 **Location Objects:**
 ```typescript

--- a/src/services/claudeExtractor.ts
+++ b/src/services/claudeExtractor.ts
@@ -317,6 +317,8 @@ venue (REQUIRED - pick ONE):
   Pub - British pub serving food
   Bar - Drinks-focused with food service
   Bakery - Bakery with seating/dining
+  Food Cart - Street-side cart or stall
+  Hole-in-the-Wall - Tiny, informal spot with minimal decor
 
 GUIDELINES:
 - cuisinePrimary: Choose the SINGLE best match from the allowed list. Use "European" for general Western cuisine that doesn't fit a specific country. Use "Martian" only as a last resort.

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -10,7 +10,7 @@ export type CuisineSecondary = CuisinePrimary; // Same values, used for fusion
 
 export type RestaurantStyle = 'Traditional' | 'Modern' | 'Fusion' | 'Casual' | 'Fine Dining' | 'Street Food';
 
-export type RestaurantVenue = 'Restaurant' | 'Cafe' | 'Pub' | 'Bar' | 'Bakery';
+export type RestaurantVenue = 'Restaurant' | 'Cafe' | 'Pub' | 'Bar' | 'Bakery' | 'Food cart' | 'Hole-in-the-wall';
 
 export type RestaurantSpecialty =
   | 'BBQ' | 'Seafood' | 'Steakhouse' | 'Ramen' | 'Pizza' | 'Sushi' | 'Tapas' | 'Tasting Menu' | 'Brunch' | 'Breakfast';
@@ -29,7 +29,7 @@ export const STYLE_OPTIONS: RestaurantStyle[] = [
 ];
 
 export const VENUE_OPTIONS: RestaurantVenue[] = [
-  'Restaurant', 'Cafe', 'Pub', 'Bar', 'Bakery'
+  'Restaurant', 'Cafe', 'Pub', 'Bar', 'Bakery', 'Food cart', 'Hole-in-the-wall'
 ];
 
 export const SPECIALTY_OPTIONS: RestaurantSpecialty[] = [

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -10,7 +10,7 @@ export type CuisineSecondary = CuisinePrimary; // Same values, used for fusion
 
 export type RestaurantStyle = 'Traditional' | 'Modern' | 'Fusion' | 'Casual' | 'Fine Dining' | 'Street Food';
 
-export type RestaurantVenue = 'Restaurant' | 'Cafe' | 'Pub' | 'Bar' | 'Bakery' | 'Food cart' | 'Hole-in-the-wall';
+export type RestaurantVenue = 'Restaurant' | 'Cafe' | 'Pub' | 'Bar' | 'Bakery' | 'Food Cart' | 'Hole-in-the-Wall';
 
 export type RestaurantSpecialty =
   | 'BBQ' | 'Seafood' | 'Steakhouse' | 'Ramen' | 'Pizza' | 'Sushi' | 'Tapas' | 'Tasting Menu' | 'Brunch' | 'Breakfast';
@@ -29,7 +29,7 @@ export const STYLE_OPTIONS: RestaurantStyle[] = [
 ];
 
 export const VENUE_OPTIONS: RestaurantVenue[] = [
-  'Restaurant', 'Cafe', 'Pub', 'Bar', 'Bakery', 'Food cart', 'Hole-in-the-wall'
+  'Restaurant', 'Cafe', 'Pub', 'Bar', 'Bakery', 'Food Cart', 'Hole-in-the-Wall'
 ];
 
 export const SPECIALTY_OPTIONS: RestaurantSpecialty[] = [


### PR DESCRIPTION
## Summary
- Adds `'Food cart'` and `'Hole-in-the-wall'` to the `RestaurantVenue` union type
- Updates `VENUE_OPTIONS` array so both appear in UI dropdowns
- Also commits previously pending `prReviewMode` → `"enabled"` in `project-config.json`

## Test plan
- [ ] Venue dropdown in the admin panel shows the two new options
- [ ] Filtering by venue type works for the new values
- [ ] TypeScript build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)