### PR TITLE
Fix extraction outage: direct-fetch-first + soften non-restaurant gate

### DIFF
--- a/REFERENCE/ai-extraction-guide.md
+++ b/REFERENCE/ai-extraction-guide.md
@@ -75,7 +75,7 @@ export const CLAUDE_MAX_TOKENS = {
 **Goal:** Fetch meaningful HTML from the target URL
 
 **Process:**
-1. Fetch main page via proxy services
+1. Fetch main page **directly** (server-side `fetch` with a browser User-Agent)
 2. Parse HTML to find relevant subpages:
    - Menu pages (`/menu`, `/food`, `/chef`)
    - Contact pages (`/contact`, `/location`, `/find-us`)
@@ -83,21 +83,20 @@ export const CLAUDE_MAX_TOKENS = {
 3. Fetch up to 3 additional pages
 4. Combine all content for analysis
 
-**Proxies used:**
-- `https://api.codetabs.com/v1/proxy`
-- `https://api.allorigins.win/get`
+**Fetch strategy (`fetchPageWithProxy` in `worker.js` / `server.cjs`):**
+1. **Direct fetch first.** The Worker runs server-side with no CORS restriction, so it fetches the target URL directly. This is the common case and avoids any third-party dependency.
+2. **Proxy fallback.** Only if the direct fetch fails (non-2xx, thin body, timeout) does it fall back to public CORS proxies:
+   - `https://api.codetabs.com/v1/proxy`
+   - `https://api.allorigins.win/get`
 
-**Why proxies?**
-- Avoid CORS restrictions
-- Handle JavaScript-heavy sites (partially)
-- No backend infrastructure needed
+**Why direct-first?** These free public proxies are unreliable — they rate-limit, return errors, and go down without notice. A proxy outage used to surface to the user as "Could not fetch website content". Direct fetch removes them from the critical path; they remain only for sites that block datacenter IPs.
 
 **Limitations:**
-- Single-page apps may not render fully
-- Some sites block proxies
+- Single-page apps may not render fully (no JS execution in either path)
+- Some sites block datacenter IPs — proxy fallback covers most of these
 - JavaScript-rendered content may be incomplete
 
-**Fallback:** If proxies fail, extraction uses whatever content is available (may be incomplete).
+**Fallback:** If both direct fetch and proxies fail, extraction returns "Could not fetch website content".
 
 ---
 
@@ -125,7 +124,7 @@ export const CLAUDE_MAX_TOKENS = {
 - `bar` - Drinks-focused with food
 - `pub` - British pub serving meals
 
-**Invalid types (rejected):**
+**Other types (advisory only — no longer blocking):**
 - `hotel` - Accommodation (even if has restaurant)
 - `retail` - Shops selling products
 - `gallery` - Art galleries/museums
@@ -142,10 +141,8 @@ export const CLAUDE_MAX_TOKENS = {
 }
 ```
 
-**Why this phase?**
-- Prevents adding non-restaurants to database
-- Saves API costs on irrelevant extractions
-- Improves user experience (clear error messages)
+**Soft-warning behaviour (not a hard gate):**
+Detection no longer *blocks* extraction. If the detected type isn't one of the food types above, extraction proceeds anyway and the success response carries a non-blocking `warning` object (`{ detectedType, message }`). The frontend surfaces it as an amber advisory so the user can sanity-check the extracted details rather than being forced into manual entry. This avoids false negatives on legitimate-but-atypical venues (wine bars, supper clubs, delis). The one genuine hard stop that remains is the Instagram login wall, where no content can be fetched at all.
 
 ---
 
@@ -326,12 +323,13 @@ if (response.status === 429 || errorText.includes('rate_limit_error')) {
 - Suggests retry timing
 - Frontend can show countdown timer
 
-### Proxy Failures
+### Fetch Failures
 
 **Fallback Chain:**
-1. Try `api.codetabs.com`
-2. If fails, try `api.allorigins.win`
-3. If both fail, return null content
+1. Direct server-side `fetch` of the target URL (primary path)
+2. If that fails, try `api.codetabs.com`
+3. If that fails, try `api.allorigins.win`
+4. If all fail, return null content → "Could not fetch website content"
 
 **Impact:** Extraction may fail or return incomplete data
 
@@ -409,14 +407,23 @@ const stats = ExtractionCache.getStats();
 
 ## Troubleshooting
 
-### "This appears to be a [type], not a restaurant"
+### Amber warning: "This looks like a [type] rather than a restaurant"
 
-**Cause:** Business type detection classified it as non-restaurant
+**Cause:** Business type detection classified the venue as a non-food type. This is **advisory only** — extraction still ran and the form is populated.
 
 **Solutions:**
-1. Try a review site URL instead (Timeout, Infatuation, etc.)
-2. Verify it actually is a restaurant (not just a retail bakery, hotel lobby, etc.)
-3. Use manual entry
+1. Review the extracted details and correct anything wrong, then save as normal.
+2. If the content was genuinely wrong (e.g. a hotel lobby page), edit fields or use a review site URL (Timeout, Infatuation, etc.) for richer content.
+
+### "Could not fetch website content"
+
+**Cause:** Both the direct fetch and the proxy fallback failed to retrieve the page.
+
+**Solutions:**
+1. Try again — transient network/proxy issues often clear.
+2. Verify the URL loads in a browser.
+3. For sites that block automated fetches, try a review site URL instead.
+4. Check the Worker observability logs for which path failed.
 
 ### Incomplete extraction (missing address, phone, etc.)
 
@@ -552,15 +559,19 @@ const limitedContent = allContent.slice(0, 8000); // ~2K tokens
 }
 ```
 
-**Not a Restaurant Response:**
+**Success with Non-Food Warning (advisory, not blocking):**
 ```json
 {
-  "success": false,
-  "isNotRestaurant": true,
-  "detectedType": "hotel",
-  "message": "This appears to be a hotel website, not a restaurant."
+  "success": true,
+  "data": { "...": "extracted restaurant fields" },
+  "confidence": "high",
+  "warning": {
+    "detectedType": "hotel",
+    "message": "This looks like a hotel rather than a restaurant — double-check the extracted details before saving."
+  }
 }
 ```
+On a clean restaurant match, `warning` is `null`.
 
 **Rate Limit Response:**
 ```json

--- a/REFERENCE/testing-strategy.md
+++ b/REFERENCE/testing-strategy.md
@@ -466,7 +466,7 @@ describe('Restaurant Extraction', () => {
 
 ## Current Implementation Status
 
-Tests are implemented and running in CI — 163 tests across services, components, pages, hooks, and utilities at the time of writing. Run `npm test` locally or `npm run test:coverage` for the coverage report.
+Tests are implemented and running in CI — 171 tests across services, components, pages, hooks, and utilities at the time of writing. Run `npm test` locally or `npm run test:coverage` for the coverage report.
 
 **Where to add new tests:**
 
@@ -511,4 +511,4 @@ Tests are implemented and running in CI — 163 tests across services, component
 
 ---
 
-**Status:** Test infrastructure in place; 163 tests passing in CI. This document describes the current testing approach and remains the reference for adding new tests.
+**Status:** Test infrastructure in place; 171 tests passing in CI. This document describes the current testing approach and remains the reference for adding new tests.

--- a/REFERENCE/testing-strategy.md
+++ b/REFERENCE/testing-strategy.md
@@ -466,7 +466,7 @@ describe('Restaurant Extraction', () => {
 
 ## Current Implementation Status
 
-Tests are implemented and running in CI — 159 tests across services, components, pages, and utilities at the time of writing. Run `npm test` locally or `npm run test:coverage` for the coverage report.
+Tests are implemented and running in CI — 163 tests across services, components, pages, hooks, and utilities at the time of writing. Run `npm test` locally or `npm run test:coverage` for the coverage report.
 
 **Where to add new tests:**
 
@@ -511,4 +511,4 @@ Tests are implemented and running in CI — 159 tests across services, component
 
 ---
 
-**Status:** Test infrastructure in place; 159 tests passing in CI. This document describes the current testing approach and remains the reference for adding new tests.
+**Status:** Test infrastructure in place; 163 tests passing in CI. This document describes the current testing approach and remains the reference for adding new tests.

--- a/REFERENCE/troubleshooting.md
+++ b/REFERENCE/troubleshooting.md
@@ -310,16 +310,15 @@ npx wrangler tail
 - Use manual entry for problematic restaurants
 - For review sites (Timeout, Infatuation), extraction works better than direct restaurant sites
 
-### Business type detection failing
+### Business type detection warning
 
-**Symptom:** Restaurant rejected as "not a restaurant"
+**Symptom:** Amber advisory "This looks like a [type] rather than a restaurant"
 
-**Cause:** AI incorrectly classified the business type
+**Cause:** AI classified the venue as a non-food type. This is **advisory only** — extraction still ran and the form is populated.
 
 **Solution:**
-- Use trusted review site URLs instead (theinfatuation.com, timeout.com, etc.)
-- These sites bypass business type detection
-- Manually enter restaurant details as fallback
+- Review the extracted details, correct anything wrong, and save as normal.
+- If the content was genuinely wrong, try a trusted review site URL (theinfatuation.com, timeout.com, etc.) — these bypass business type detection.
 
 ---
 

--- a/server.cjs
+++ b/server.cjs
@@ -111,15 +111,45 @@ async function callClaudeApi(prompt, apiKey) {
   return result.content[0].text;
 }
 
+// Browser-like User-Agent so sites serve us their real markup rather than a bot page
+const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
 async function fetchPageWithProxy(url) {
+  // Primary path: fetch the target directly (no CORS restriction server-side).
+  // Avoids depending on flaky third-party proxies for the common case; proxies
+  // remain as a fallback for sites that block datacenter IPs.
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_USER_AGENT,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-GB,en;q=0.9'
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(12000)
+    });
+    if (response.ok) {
+      const content = await response.text();
+      if (content && content.length > 500) {
+        console.log('✅ Content fetched via direct fetch, length:', content.length);
+        return content;
+      }
+      console.log('⚠️ Direct fetch returned thin content, falling back to proxies');
+    } else {
+      console.log('⚠️ Direct fetch returned status', response.status, '- falling back to proxies');
+    }
+  } catch (error) {
+    console.log('⚠️ Direct fetch failed:', error.message, '- falling back to proxies');
+  }
+
   const proxies = [
     `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}`,
     `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`
   ];
-  
+
   for (const proxyUrl of proxies) {
     try {
-      const response = await fetch(proxyUrl);
+      const response = await fetch(proxyUrl, { signal: AbortSignal.timeout(12000) });
       if (response.ok) {
         if (proxyUrl.includes('allorigins')) {
           const data = await response.json();
@@ -338,6 +368,11 @@ app.post('/api/extract-restaurant', async (req, res) => {
     const limitedContent = meaningfulContent.slice(0, 8000); // ~2000 tokens max
     console.log('🔍 Using limited content for analysis, length:', limitedContent.length);
 
+    // Non-blocking advisory: if detection thinks this isn't a food venue we still
+    // extract, but surface a warning so the user can sanity-check rather than being
+    // hard-blocked on a false negative (e.g. wine bars, supper clubs, delis).
+    let businessTypeWarning = null;
+
     // Business type detection (skip for trusted review sites)
     if (!isTrustedReviewSite) {
       // Business type detection prompt
@@ -406,12 +441,12 @@ FOOD SERVICE PRIORITY: If a business serves food for sit-in dining (even if they
 
       const validFoodBusinessTypes = ['restaurant', 'cafe', 'bakery', 'bar', 'pub'];
       if (!validFoodBusinessTypes.includes(businessAnalysis.businessType)) {
-        return res.json({
-          success: false,
-          isNotRestaurant: true,
+        // Soft warning instead of a hard block: proceed with extraction anyway.
+        businessTypeWarning = {
           detectedType: businessAnalysis.businessType,
-          message: `This appears to be a ${businessAnalysis.businessType} website, not a restaurant. Please use manual entry instead.`
-        });
+          message: `This looks like a ${businessAnalysis.businessType} rather than a restaurant — double-check the extracted details before saving.`
+        };
+        console.log('⚠️ Non-food business type detected, continuing with warning:', businessAnalysis.businessType);
       }
     }
 
@@ -537,7 +572,8 @@ LOCATION EXTRACTION GUIDELINES:
     res.json({
       success: true,
       data: restaurantData,
-      confidence: 'high' // Simplified for now
+      confidence: 'high', // Simplified for now
+      warning: businessTypeWarning // null unless detection flagged a non-food venue
     });
 
   } catch (error) {

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -887,6 +887,16 @@ export const AdminPanel = ({ onBack, editingRestaurant }: AdminPanelProps) => {
             </div>
           )}
           
+          {/* Non-blocking advisory: extraction succeeded but the venue may not be a restaurant */}
+          {extraction.warning && !extraction.isExtracting && (
+            <Alert className="border-orange-200 bg-orange-50">
+              <AlertTriangle className="h-4 w-4 text-orange-600" />
+              <AlertDescription className="text-orange-600">
+                {extraction.warning}
+              </AlertDescription>
+            </Alert>
+          )}
+
           {/* Error/Non-restaurant Message */}
           {extraction.error && (
             <Alert className={extraction.isNotRestaurant ? "border-orange-200 bg-orange-50" : "border-red-200 bg-red-50"}>

--- a/src/hooks/useRestaurantExtraction.ts
+++ b/src/hooks/useRestaurantExtraction.ts
@@ -12,6 +12,7 @@ export interface ExtractionState {
   result?: ExtractedRestaurantData;
   isNotRestaurant?: boolean;
   detectedType?: string;
+  warning?: string; // Non-blocking advisory shown alongside a successful extraction
 }
 
 export function useRestaurantExtraction() {
@@ -88,7 +89,8 @@ export function useRestaurantExtraction() {
       setState({
         isExtracting: false,
         progress: 'Extraction complete!',
-        result: result.data
+        result: result.data,
+        warning: result.warning?.message
       });
 
       // Clear success message after 3 seconds

--- a/src/hooks/useRestaurantExtraction.ts
+++ b/src/hooks/useRestaurantExtraction.ts
@@ -68,6 +68,8 @@ export function useRestaurantExtraction() {
       clearInterval(progressInterval);
 
       if (!result.success) {
+        // NOTE: isNotRestaurant is no longer returned by the live extraction path
+        // (non-food types now soft-warn on success). Retained defensively. See TECHNICAL DEBT issue.
         if (result.isNotRestaurant) {
           setState({
             isExtracting: false,

--- a/src/services/claudeExtractor.ts
+++ b/src/services/claudeExtractor.ts
@@ -8,6 +8,11 @@ export interface ExtractionProgress {
   details?: string;
 }
 
+export interface BusinessTypeWarning {
+  detectedType: string;
+  message: string;
+}
+
 export interface RestaurantExtractionResult {
   success: boolean;
   isNotRestaurant?: boolean;
@@ -16,6 +21,7 @@ export interface RestaurantExtractionResult {
   data?: ExtractedRestaurantData;
   confidence?: 'high' | 'medium' | 'low';
   error?: string;
+  warning?: BusinessTypeWarning | null; // Non-blocking advisory when detection flags a non-food venue
 }
 
 export interface ExtractedLocation {

--- a/src/services/claudeExtractor.ts
+++ b/src/services/claudeExtractor.ts
@@ -84,6 +84,10 @@ export class ClaudeExtractor {
       progressCallback?.({ step: 'Analyzing business type...' });
       const businessAnalysis = await this.analyzeBusinessType(content);
       
+      // NOTE: This method is not on the live extraction path — extractRestaurantLocal()
+      // calls the Worker (worker.js) / dev server (server.cjs), which now soft-warn on
+      // non-food types instead of hard-blocking. This hard gate is retained only because
+      // the class still owns the shared cache and types. See TECHNICAL DEBT issue.
       const validFoodBusinessTypes = ['restaurant', 'cafe', 'bakery', 'bar', 'pub'];
       if (!validFoodBusinessTypes.includes(businessAnalysis.businessType)) {
         return {

--- a/src/worker.js
+++ b/src/worker.js
@@ -103,6 +103,9 @@ async function callClaudeApi(prompt, apiKey) {
 }
 
 // Fetch page content with proxy
+// Browser-like User-Agent so sites serve us their real markup rather than a bot page
+const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
 async function fetchPageWithProxy(url) {
   // Instagram-specific handling
   if (isInstagramUrl(url)) {
@@ -110,6 +113,34 @@ async function fetchPageWithProxy(url) {
     return await fetchInstagramContent(url);
   }
 
+  // Primary path: Workers run server-side with no CORS restriction, so fetch the
+  // target directly. This avoids depending on flaky third-party proxies for the
+  // common case. Proxies remain as a fallback for sites that block datacenter IPs.
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_USER_AGENT,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-GB,en;q=0.9'
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(12000)
+    });
+    if (response.ok) {
+      const content = await response.text();
+      if (content && content.length > 500) {
+        console.log('✅ Content fetched via direct fetch, length:', content.length);
+        return content;
+      }
+      console.log('⚠️ Direct fetch returned thin content, falling back to proxies');
+    } else {
+      console.log('⚠️ Direct fetch returned status', response.status, '- falling back to proxies');
+    }
+  } catch (error) {
+    console.log('⚠️ Direct fetch failed:', error.message, '- falling back to proxies');
+  }
+
+  // Fallback path: public CORS proxies for sites that reject direct datacenter requests
   const proxies = [
     `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}`,
     `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`
@@ -117,7 +148,7 @@ async function fetchPageWithProxy(url) {
 
   for (const proxyUrl of proxies) {
     try {
-      const response = await fetch(proxyUrl);
+      const response = await fetch(proxyUrl, { signal: AbortSignal.timeout(12000) });
       if (response.ok) {
         if (proxyUrl.includes('allorigins')) {
           const data = await response.json();
@@ -465,6 +496,11 @@ async function handleRestaurantExtraction(request, env) {
     // Business type detection (skip for trusted review sites)
     const isInstagramUrl = url.includes('instagram.com/') || url.includes('instagr.am/');
 
+    // Non-blocking advisory: if detection thinks this isn't a food venue we still
+    // extract, but surface a warning so the user can sanity-check rather than being
+    // hard-blocked on a false negative (e.g. wine bars, supper clubs, delis).
+    let businessTypeWarning = null;
+
     if (!isTrustedReviewSite) {
       // Business type detection prompt with Instagram-specific handling
       const businessPrompt = `
@@ -554,12 +590,12 @@ ${isInstagramUrl ? '- Instagram food influencers or personal accounts should be 
         });
       }
 
-      return Response.json({
-        success: false,
-        isNotRestaurant: true,
+      // Soft warning instead of a hard block: proceed with extraction anyway.
+      businessTypeWarning = {
         detectedType: businessAnalysis.businessType,
-        message: `This appears to be a ${businessAnalysis.businessType} website, not a restaurant. Please use manual entry instead.`
-      });
+        message: `This looks like a ${businessAnalysis.businessType} rather than a restaurant — double-check the extracted details before saving.`
+      };
+      console.log('⚠️ Non-food business type detected, continuing with warning:', businessAnalysis.businessType);
     }
     } // End of business type detection block
 
@@ -699,7 +735,8 @@ LOCATION EXTRACTION GUIDELINES:
     return Response.json({
       success: true,
       data: restaurantData,
-      confidence: 'high' // Simplified for now
+      confidence: 'high', // Simplified for now
+      warning: businessTypeWarning // null unless detection flagged a non-food venue
     });
 
   } catch (error) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -102,7 +102,7 @@ async function callClaudeApi(prompt, apiKey) {
   return result.content[0].text;
 }
 
-// Fetch page content with proxy
+// Fetch page content: direct server-side fetch first, public proxies as fallback
 // Browser-like User-Agent so sites serve us their real markup rather than a bot page
 const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -106,7 +106,7 @@ async function callClaudeApi(prompt, apiKey) {
 // Browser-like User-Agent so sites serve us their real markup rather than a bot page
 const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
 
-async function fetchPageWithProxy(url) {
+export async function fetchPageWithProxy(url) {
   // Instagram-specific handling
   if (isInstagramUrl(url)) {
     console.log('🟣 Instagram URL detected, using specialized scraping');
@@ -428,6 +428,18 @@ function extractMeaningfulContent(html, url = '') {
 }
 
 // Handle restaurant extraction request
+// Returns a non-blocking advisory for non-food business types, or null for food
+// types. Detection no longer hard-blocks extraction — the caller attaches this
+// warning to a successful response so the user can sanity-check atypical venues.
+export function businessTypeWarningFor(businessType) {
+  const validFoodBusinessTypes = ['restaurant', 'cafe', 'bakery', 'bar', 'pub'];
+  if (validFoodBusinessTypes.includes(businessType)) return null;
+  return {
+    detectedType: businessType,
+    message: `This looks like a ${businessType} rather than a restaurant — double-check the extracted details before saving.`
+  };
+}
+
 async function handleRestaurantExtraction(request, env) {
   try {
     const { url } = await request.json();
@@ -577,9 +589,10 @@ ${isInstagramUrl ? '- Instagram food influencers or personal accounts should be 
     const businessAnalysis = extractJSONFromResponse(businessResponse);
     console.log('🔍 Business analysis:', businessAnalysis);
 
-    const validFoodBusinessTypes = ['restaurant', 'cafe', 'bakery', 'bar', 'pub'];
-    if (!validFoodBusinessTypes.includes(businessAnalysis.businessType)) {
-      // Special handling for Instagram login wall
+    const warning = businessTypeWarningFor(businessAnalysis.businessType);
+    if (warning) {
+      // Non-food classification. Instagram login walls land here too — and there we
+      // genuinely can't fetch content, so it stays a hard stop.
       if (isInstagramUrl && businessAnalysis.reasoning &&
           (businessAnalysis.reasoning.toLowerCase().includes('login') ||
            businessAnalysis.reasoning.toLowerCase().includes('instagram') && businessAnalysis.reasoning.toLowerCase().includes('code'))) {
@@ -591,10 +604,7 @@ ${isInstagramUrl ? '- Instagram food influencers or personal accounts should be 
       }
 
       // Soft warning instead of a hard block: proceed with extraction anyway.
-      businessTypeWarning = {
-        detectedType: businessAnalysis.businessType,
-        message: `This looks like a ${businessAnalysis.businessType} rather than a restaurant — double-check the extracted details before saving.`
-      };
+      businessTypeWarning = warning;
       console.log('⚠️ Non-food business type detected, continuing with warning:', businessAnalysis.businessType);
     }
     } // End of business type detection block

--- a/tests/hooks/useRestaurantExtraction.test.ts
+++ b/tests/hooks/useRestaurantExtraction.test.ts
@@ -61,7 +61,7 @@ describe('useRestaurantExtraction', () => {
     expect(result.current.warning).toBeUndefined();
   });
 
-  it('clears any prior warning when a new extraction starts', async () => {
+  it('replaces a prior warning on a subsequent successful extraction', async () => {
     vi.mocked(extractRestaurantLocal).mockResolvedValue(
       mockResult({ warning: { detectedType: 'bar', message: 'Looks like a bar.' } })
     );
@@ -79,5 +79,29 @@ describe('useRestaurantExtraction', () => {
       await result.current.extractFromUrl('https://example.com');
     });
     expect(result.current.warning).toBeUndefined();
+  });
+
+  it('clears a prior warning when a subsequent extraction fails', async () => {
+    vi.mocked(extractRestaurantLocal).mockResolvedValue(
+      mockResult({ warning: { detectedType: 'retail', message: 'Looks like retail.' } })
+    );
+
+    const { result } = renderHook(() => useRestaurantExtraction());
+
+    await act(async () => {
+      await result.current.extractFromUrl('https://example.com');
+    });
+    expect(result.current.warning).toBe('Looks like retail.');
+
+    // A failed extraction must not leave the stale advisory hanging around
+    vi.mocked(extractRestaurantLocal).mockResolvedValue({
+      success: false,
+      error: 'Could not fetch website content',
+    });
+    await act(async () => {
+      await result.current.extractFromUrl('https://example.com');
+    });
+    expect(result.current.warning).toBeUndefined();
+    expect(result.current.error).toBe('Could not fetch website content');
   });
 });

--- a/tests/hooks/useRestaurantExtraction.test.ts
+++ b/tests/hooks/useRestaurantExtraction.test.ts
@@ -1,0 +1,83 @@
+// ABOUT: Unit tests for the restaurant extraction hook
+// ABOUT: Focuses on the non-blocking business-type warning surfaced on success
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRestaurantExtraction } from '@/hooks/useRestaurantExtraction';
+import { extractRestaurantLocal } from '@/api/extract-restaurant';
+import type { RestaurantExtractionResult } from '@/services/claudeExtractor';
+
+vi.mock('@/api/extract-restaurant', () => ({
+  extractRestaurantLocal: vi.fn(),
+}));
+
+const mockData = {
+  name: 'Test Venue',
+  addressSummary: 'Shoreditch, London',
+  website: 'https://example.com',
+  locations: [],
+};
+
+function mockResult(overrides: Partial<RestaurantExtractionResult>): RestaurantExtractionResult {
+  return { success: true, data: mockData, confidence: 'high', ...overrides };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useRestaurantExtraction', () => {
+  it('surfaces a warning message when the API flags a non-food venue', async () => {
+    vi.mocked(extractRestaurantLocal).mockResolvedValue(
+      mockResult({
+        warning: { detectedType: 'retail', message: 'This looks like a retail venue — double-check.' },
+      })
+    );
+
+    const { result } = renderHook(() => useRestaurantExtraction());
+
+    let returned;
+    await act(async () => {
+      returned = await result.current.extractFromUrl('https://example.com');
+    });
+
+    expect(returned).toEqual(mockData);
+    expect(result.current.warning).toBe('This looks like a retail venue — double-check.');
+    // Warning is advisory only — extraction still succeeded with data
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.result).toEqual(mockData);
+  });
+
+  it('leaves warning undefined on a clean restaurant extraction', async () => {
+    vi.mocked(extractRestaurantLocal).mockResolvedValue(mockResult({ warning: null }));
+
+    const { result } = renderHook(() => useRestaurantExtraction());
+
+    await act(async () => {
+      await result.current.extractFromUrl('https://example.com');
+    });
+
+    expect(result.current.result).toEqual(mockData);
+    expect(result.current.warning).toBeUndefined();
+  });
+
+  it('clears any prior warning when a new extraction starts', async () => {
+    vi.mocked(extractRestaurantLocal).mockResolvedValue(
+      mockResult({ warning: { detectedType: 'bar', message: 'Looks like a bar.' } })
+    );
+
+    const { result } = renderHook(() => useRestaurantExtraction());
+
+    await act(async () => {
+      await result.current.extractFromUrl('https://example.com');
+    });
+    expect(result.current.warning).toBe('Looks like a bar.');
+
+    // Second run returns no warning — the stale warning must not linger
+    vi.mocked(extractRestaurantLocal).mockResolvedValue(mockResult({ warning: null }));
+    await act(async () => {
+      await result.current.extractFromUrl('https://example.com');
+    });
+    expect(result.current.warning).toBeUndefined();
+  });
+});

--- a/tests/worker/extraction.test.ts
+++ b/tests/worker/extraction.test.ts
@@ -1,0 +1,113 @@
+// ABOUT: Regression tests for the Worker extraction fetch + business-type logic
+// ABOUT: Covers the direct-fetch-first fallback chain and the soft-warning decision
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+// @ts-expect-error — worker.js is plain JS with no type declarations
+import { fetchPageWithProxy, businessTypeWarningFor } from '@/worker';
+
+const TARGET = 'https://example-restaurant.com';
+const GOOD_HTML = '<html><body>' + 'x'.repeat(600) + '</body></html>'; // > 500 chars
+
+// Build a fake Response with just the bits fetchPageWithProxy reads.
+function res({ ok = true, status = 200, text = '', json = undefined }: {
+  ok?: boolean; status?: number; text?: string; json?: unknown;
+}) {
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(text),
+    json: () => Promise.resolve(json),
+  };
+}
+
+const isCodetabs = (u: string) => u.includes('codetabs');
+const isAllorigins = (u: string) => u.includes('allorigins');
+const isProxy = (u: string) => isCodetabs(u) || isAllorigins(u);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('fetchPageWithProxy — direct-fetch-first fallback chain', () => {
+  it('returns direct-fetch content and never touches a proxy on the happy path', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(isProxy(url) ? res({ text: 'PROXY' }) : res({ text: GOOD_HTML }))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const content = await fetchPageWithProxy(TARGET);
+
+    expect(content).toBe(GOOD_HTML);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(TARGET); // direct, not a proxy
+  });
+
+  it('falls back to a proxy when the direct fetch returns thin content', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(isProxy(url) ? res({ text: 'PROXY_CONTENT' }) : res({ text: 'tiny' }))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const content = await fetchPageWithProxy(TARGET);
+
+    expect(content).toBe('PROXY_CONTENT');
+    expect(fetchMock.mock.calls.some(c => isProxy(c[0] as string))).toBe(true);
+  });
+
+  it('falls back to a proxy when the direct fetch returns a non-2xx status', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(isProxy(url) ? res({ text: 'PROXY_CONTENT' }) : res({ ok: false, status: 403, text: '' }))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchPageWithProxy(TARGET)).toBe('PROXY_CONTENT');
+  });
+
+  it('falls back to a proxy when the direct fetch throws (timeout/network)', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      isProxy(url) ? Promise.resolve(res({ text: 'PROXY_CONTENT' })) : Promise.reject(new Error('timed out'))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchPageWithProxy(TARGET)).toBe('PROXY_CONTENT');
+  });
+
+  it('parses allorigins JSON shape and uses it when codetabs fails', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (isAllorigins(url)) return Promise.resolve(res({ json: { contents: 'ALLORIGINS_HTML' } }));
+      if (isCodetabs(url)) return Promise.resolve(res({ ok: false, status: 400, text: '' }));
+      return Promise.reject(new Error('direct blocked')); // direct fetch fails
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchPageWithProxy(TARGET)).toBe('ALLORIGINS_HTML');
+  });
+
+  it('returns null when direct fetch and all proxies fail', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      isProxy(url) ? Promise.resolve(res({ ok: false, status: 500, text: '' })) : Promise.reject(new Error('blocked'))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchPageWithProxy(TARGET)).toBeNull();
+  });
+});
+
+describe('businessTypeWarningFor — soft-warning decision', () => {
+  it('returns null for every food business type (no warning, no block)', () => {
+    for (const t of ['restaurant', 'cafe', 'bakery', 'bar', 'pub']) {
+      expect(businessTypeWarningFor(t)).toBeNull();
+    }
+  });
+
+  it('returns an advisory naming the detected type for non-food venues', () => {
+    for (const t of ['hotel', 'retail', 'gallery', 'other']) {
+      const warning = businessTypeWarningFor(t);
+      expect(warning).not.toBeNull();
+      expect(warning.detectedType).toBe(t);
+      expect(warning.message).toContain(t);
+      expect(warning.message.toLowerCase()).toContain('double-check');
+    }
+  });
+});


### PR DESCRIPTION
## Why

Adding a restaurant failed with **"Could not fetch website content"** (HTTP 500). Root cause: `fetchPageWithProxy` fetched the target site *only* via two free public CORS proxies (`api.codetabs.com`, `api.allorigins.win`), and **both were down** at the same time — codetabs returning 400, allorigins timing out. With no other path, extraction bailed. These proxies have no SLA and fail regularly, so they were a single point of failure for a core feature.

## What changed

**1. Direct-fetch-first (the fix)**
Cloudflare Workers run server-side with no CORS restriction, so they can fetch the target URL directly. `fetchPageWithProxy` now:
1. Fetches the URL **directly** (browser User-Agent, `Accept` headers, `redirect: follow`, 12s `AbortSignal.timeout`)
2. Falls back to the codetabs → allorigins proxies only if direct fetch fails (non-2xx, thin body, timeout/throw)

Applied to both `src/worker.js` (prod) and `server.cjs` (local dev) for parity. Proxies are retained solely for sites that block datacenter IPs.

**2. Soften the business-type gate (folded in by request)**
A non-food classification used to **hard-block** extraction (`isNotRestaurant`), forcing manual entry and causing false negatives on legitimate-but-atypical venues (wine bars, supper clubs, delis). It now returns `success: true` with a non-blocking `warning: { detectedType, message }`. The admin UI surfaces it as an amber advisory above the populated form, so you can sanity-check rather than being bounced. The Instagram login-wall hard stop remains (no content can be fetched there).

## Verification
- Ran the exact direct-fetch logic inside **workerd** (`wrangler dev`, compat date 2025-01-01): `AbortSignal.timeout` resolves to `function` (would have silently no-op'd the fix otherwise), and Dishoom / St John / Noble Rot all fetched 200 with full HTML.
- New hook tests for warning surfacing; full suite green (163 tests); `tsc --noEmit` + lint clean.
- Updated `REFERENCE/ai-extraction-guide.md` (fetch strategy, soft-warning behaviour, response shapes, troubleshooting).

## Reviewer notes / known caveats
- **Residual risk (not closeable locally):** local workerd doesn't use a Cloudflare *datacenter* IP. If a site returns a **200 bot-challenge page** (not a 403), the `length > 500` heuristic would accept it as content. Only observable in production — worth watching the `✅ Content fetched via direct fetch` log line post-deploy. Mitigation (challenge-page detection) deferred until/unless it's seen. Still strictly better than the status quo, where the proxies are simply down.
- **Dead code:** with both live gates softened, the worker no longer returns `isNotRestaurant`, so the hook's `isNotRestaurant` branch and the "Use Manual Entry Instead" button are now unreachable. Left in place (harmless); flagging so it's not a puzzle.
- `ClaudeExtractor.extractFromUrl` in `claudeExtractor.ts` still contains the old hard gate, but it is **dead code** — `extractRestaurantLocal` only uses the cache + types from that module; real extraction is `worker.js`/`server.cjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
