### PR TITLE
Fix extraction 503: migrate retired Sonnet 4 → Sonnet 4.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Model versions are centralized in `src/config/claude.ts`. When Anthropic depreca
 - **Frontend**: React 18 + TypeScript + Vite + Tailwind CSS + shadcn/ui
 - **Backend**: Cloudflare D1 (SQLite) + Cloudflare Workers
 - **Auth**: Cloudflare Access + Google OAuth (JWT verified server-side in Worker)
-- **AI**: Claude Sonnet 4.5 for restaurant extraction and review summarization
+- **AI**: Claude Sonnet 4.6 for restaurant extraction and review summarization
 - **Maps**: Mapbox GL JS with clustering
 - **Geo**: Google Maps Geocoding and Places APIs
 
@@ -110,7 +110,7 @@ interface RestaurantAddress {
 
 ### Claude Model Updates
 
-**Current Model**: `claude-sonnet-4-20250514` (Sonnet 4.5)
+**Current Model**: `claude-sonnet-4-6` (Sonnet 4.6)
 
 ### Static assets and SPA routing
 Cloudflare Workers Static Assets handles everything end-to-end: `dist/client/` is served directly, and `not_found_handling = "single-page-application"` in `wrangler.toml` returns `index.html` for unmatched non-API paths. `run_worker_first` keeps `/api/*` and `/auth/login` on the Worker. No hand-rolled HTML fallback in the Worker, no asset-reference sync script.

--- a/REFERENCE/DEVELOPMENT.md
+++ b/REFERENCE/DEVELOPMENT.md
@@ -158,7 +158,7 @@ npx wrangler deploy
 
 Model versions are centralised in `src/config/claude.ts` (TypeScript) and as constants at the top of `server.cjs` and `src/worker.js` (Node.js files). When Anthropic deprecates a model, update these and redeploy. See `REFERENCE/claude_model_updates.md` for step-by-step instructions.
 
-**Current model:** `claude-sonnet-4-20250514` (Sonnet 4.5)
+**Current model:** `claude-sonnet-4-6` (Sonnet 4.6)
 
 ---
 

--- a/REFERENCE/ai-extraction-guide.md
+++ b/REFERENCE/ai-extraction-guide.md
@@ -48,12 +48,12 @@ Admin Panel → restaurants.hultberg.org/api/extract-restaurant → Claude API �
 
 ## Current Model Configuration
 
-**Model:** `claude-sonnet-4-20250514` (Sonnet 4.5)
+**Model:** `claude-sonnet-4-6` (Sonnet 4.6)
 
 **Version Configuration:** `src/config/claude.ts`
 
 ```typescript
-export const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-20250514';
+export const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-6';
 export const CLAUDE_API_VERSION = '2023-06-01';
 export const CLAUDE_MAX_TOKENS = {
   EXTRACTION: 4000,

--- a/REFERENCE/claude_model_updates.md
+++ b/REFERENCE/claude_model_updates.md
@@ -2,8 +2,8 @@
 
 ## Current Model Version
 
-**Current Model:** `claude-sonnet-4-20250514` (Sonnet 4.5)
-**Last Updated:** January 2025
+**Current Model:** `claude-sonnet-4-6` (Sonnet 4.6)
+**Last Updated:** June 2026 (migrated from retired `claude-sonnet-4-20250514`)
 
 ## How to Update Claude Model Version
 
@@ -67,7 +67,8 @@ git push origin main
 
 | Model Version | Period | Notes |
 |---------------|--------|-------|
-| `claude-sonnet-4-20250514` | Jan 2025 - Present | Sonnet 4.5, current version |
+| `claude-sonnet-4-6` | Jun 2026 - Present | Sonnet 4.6, current version |
+| `claude-sonnet-4-20250514` | May 2025 - Jun 2026 | Sonnet 4, retired 15 Jun 2026 (API returned 404) |
 | `claude-3-5-sonnet-20241022` | Oct 2024 - Dec 2024 | Deprecated Dec 2024 |
 | `claude-3-5-sonnet-20240620` | Jun 2024 - Oct 2024 | Deprecated Oct 2024 |
 

--- a/REFERENCE/environment-setup.md
+++ b/REFERENCE/environment-setup.md
@@ -90,7 +90,7 @@ The Worker accesses it as `env.DB`. No connection string, no SDK initialisation.
 
 **Claude API (Anthropic):**
 - https://console.anthropic.com/settings/keys
-- Current model: `claude-sonnet-4-20250514` (configured in `src/config/claude.ts`)
+- Current model: `claude-sonnet-4-6` (configured in `src/config/claude.ts`)
 
 **Google Maps:**
 - https://console.cloud.google.com/google/maps-apis/credentials

--- a/server.cjs
+++ b/server.cjs
@@ -4,7 +4,7 @@ const cors = require('cors');
 require('dotenv').config();
 
 // Claude API configuration
-const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-20250514';
+const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-6';
 const CLAUDE_API_VERSION = '2023-06-01';
 
 const app = express();

--- a/src/config/claude.ts
+++ b/src/config/claude.ts
@@ -8,13 +8,14 @@
  * Update this when Anthropic releases new model versions.
  *
  * History:
- * - claude-sonnet-4-20250514: Current (Sonnet 4.5, January 2025)
+ * - claude-sonnet-4-6: Current (Sonnet 4.6)
+ * - claude-sonnet-4-20250514: Retired June 15, 2026 (Sonnet 4 — API returned 404 after retirement)
  * - claude-3-5-sonnet-20241022: Deprecated December 2024
  * - claude-3-5-sonnet-20240620: Deprecated October 2024
  *
  * See: https://docs.anthropic.com/en/docs/about-claude/models
  */
-export const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-20250514';
+export const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-6';
 
 /**
  * Claude API Version Header

--- a/src/worker.js
+++ b/src/worker.js
@@ -2,7 +2,7 @@
 // Migrated from server.cjs to Workers runtime
 
 // Claude API configuration
-const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-20250514';
+const CLAUDE_MODEL_VERSION = 'claude-sonnet-4-6';
 const CLAUDE_API_VERSION = '2023-06-01';
 
 // Helper function to infer city from location data


### PR DESCRIPTION
## Why

Adding a restaurant returned **HTTP 503**, and the Worker logs showed a Claude API **404 `not_found_error` for model `claude-sonnet-4-20250514`**. That model (Sonnet 4) **reached its retirement date of 15 June 2026** (six days ago), so the API no longer serves it.

This is a *second, independent* bug from the fetch outage in #51 — it only became visible because the direct-fetch fix let extraction get far enough to actually call Claude. Before #51, requests died at the fetch step and never reached the model call.

## What changed

Swap the model ID to **`claude-sonnet-4-6`** (Sonnet 4.6) — the like-for-like Sonnet-tier successor per the Anthropic model catalog.

The extraction and review-summarization requests send only `model` / `max_tokens` / `messages` — **no `temperature`, `thinking`, or assistant prefill** — so none of the Sonnet 4.6 breaking changes apply. It's a straight model-ID swap.

Updated all three call sites (the Worker and dev server still hardcode their own copies rather than importing the central config — pre-existing):
- `src/config/claude.ts` (canonical, imported by frontend services)
- `src/worker.js` (production)
- `server.cjs` (local dev)

Plus the now-accurate model references across `CLAUDE.md` and `REFERENCE/` (extraction guide, model-update runbook, environment-setup, DEVELOPMENT).

## Verification
- `tsc --noEmit` clean, lint clean (0 errors), **171 tests pass**, `wrangler deploy --dry-run` bundles.
- Model ID confirmed against the authoritative Anthropic model catalog (do **not** append a date suffix — `claude-sonnet-4-6` is complete as-is).
- Could not live-test the API call locally (the endpoint is auth-gated and needs the `CLAUDE_API_KEY` secret) — the ID swap is verified against the catalog, and behaviour will confirm on deploy.

## Note
Three call sites hardcoding the same model string is a smell — a follow-up could have `worker.js`/`server.cjs` import the central `CLAUDE_MODEL_VERSION` so the next model update is a one-line change. Out of scope here; flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)