### PR TITLE
Fix stray "0" rendering from falsy numeric && guards

### DIFF
--- a/src/components/PlaceCard.tsx
+++ b/src/components/PlaceCard.tsx
@@ -155,7 +155,7 @@ export const PlaceCard = ({ place, onStatusChange, onAppreciationChange, onEdit,
                   <MapPinned className="w-4 h-4" />
                 </Button>
               )}
-              {place.personal_rating && place.status === 'visited' && (
+              {!!place.personal_rating && place.status === 'visited' && (
                 <div className="flex items-center gap-1">
                   <span className="text-xs font-mono text-muted-foreground">Me:</span>
                   {renderStars(place.personal_rating)}
@@ -194,7 +194,7 @@ export const PlaceCard = ({ place, onStatusChange, onAppreciationChange, onEdit,
           </div>
 
           {/* Visit count */}
-          {place.visit_count && place.visit_count > 1 && (
+          {!!place.visit_count && place.visit_count > 1 && (
             <div className="flex items-center gap-1 text-sm text-muted-foreground">
               <Clock className="w-4 h-4" />
               <span>Visited {place.visit_count} times</span>
@@ -259,7 +259,7 @@ export const PlaceCard = ({ place, onStatusChange, onAppreciationChange, onEdit,
                   </Tooltip>
                 </div>
               )}
-              {place.public_rating && (
+              {!!place.public_rating && (
                 <div
                   className="flex items-center gap-1 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                   onClick={(e) => {

--- a/src/pages/RestaurantDetails.tsx
+++ b/src/pages/RestaurantDetails.tsx
@@ -630,7 +630,7 @@ const RestaurantDetails = () => {
                             </Tooltip>
                           </div>
                         )}
-                        {restaurant.public_rating && (
+                        {!!restaurant.public_rating && (
                           <div
                             className="flex items-center gap-1 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                             onClick={() => window.open(getGoogleMapsUrl(restaurant, restaurant.locations?.[0]), '_blank')}
@@ -639,7 +639,7 @@ const RestaurantDetails = () => {
                             <Star className="w-4 h-4 fill-burnt-orange text-burnt-orange" />
                             <span className="font-mono">
                               {restaurant.public_rating}/5
-                              {restaurant.public_rating_count && (
+                              {!!restaurant.public_rating_count && (
                                 <span className="ml-1">based on {restaurant.public_rating_count} ratings</span>
                               )}
                             </span>
@@ -703,7 +703,7 @@ const RestaurantDetails = () => {
                       </div>
                     )}
 
-                    {restaurant.visit_count && restaurant.visit_count > 1 && (
+                    {!!restaurant.visit_count && restaurant.visit_count > 1 && (
                       <div className="flex items-center gap-2 text-muted-foreground pt-4">
                         <Clock className="w-4 h-4" />
                         <span>Visited {restaurant.visit_count} times</span>
@@ -799,7 +799,7 @@ const RestaurantDetails = () => {
                             </Tooltip>
                           </div>
                         )}
-                        {restaurant.public_rating && (
+                        {!!restaurant.public_rating && (
                           <div
                             className="flex items-center gap-1 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
                             onClick={() => window.open(getGoogleMapsUrl(restaurant, restaurant.locations?.[0]), '_blank')}
@@ -808,7 +808,7 @@ const RestaurantDetails = () => {
                             <Star className="w-4 h-4 fill-burnt-orange text-burnt-orange" />
                             <span className="font-mono">
                               {restaurant.public_rating}/5
-                              {restaurant.public_rating_count && (
+                              {!!restaurant.public_rating_count && (
                                 <span className="ml-1">based on {restaurant.public_rating_count} ratings</span>
                               )}
                             </span>
@@ -830,7 +830,7 @@ const RestaurantDetails = () => {
                       </div>
                     )}
 
-                    {restaurant.visit_count && restaurant.visit_count > 1 && (
+                    {!!restaurant.visit_count && restaurant.visit_count > 1 && (
                       <div className="flex items-center gap-2 text-muted-foreground pt-4">
                         <Clock className="w-4 h-4" />
                         <span>Visited {restaurant.visit_count} times</span>

--- a/tests/components/PlaceCard.test.tsx
+++ b/tests/components/PlaceCard.test.tsx
@@ -37,6 +37,24 @@ const renderAt = (pathname: string) =>
     </MemoryRouter>,
   );
 
+// Detects a bare "0" rendered as a direct text node — the failure mode of a
+// falsy `0 && <JSX>` guard, where React prints the number instead of hiding it.
+const hasBareZeroTextNode = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('*')).some((el) =>
+    Array.from(el.childNodes).some(
+      (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim() === '0',
+    ),
+  );
+
+const renderCard = (place: Restaurant) =>
+  render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <PlaceCard place={place} />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+
 describe('PlaceCard navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,5 +70,24 @@ describe('PlaceCard navigation', () => {
     renderAt('/');
     fireEvent.click(screen.getByText('Test Restaurant'));
     expect(mockNavigate).toHaveBeenCalledWith('/restaurant/r1', { state: { from: '/' } });
+  });
+});
+
+describe('PlaceCard falsy-zero guards', () => {
+  it('does not render a stray "0" when numeric fields are 0', () => {
+    const { container } = renderCard(
+      makeRestaurant({
+        status: 'visited',
+        visit_count: 0,
+        public_rating: 0,
+        personal_rating: 0,
+      }),
+    );
+    expect(hasBareZeroTextNode(container)).toBe(false);
+  });
+
+  it('still renders the visit count when visited more than once', () => {
+    renderCard(makeRestaurant({ status: 'visited', visit_count: 3 }));
+    expect(screen.getByText('Visited 3 times')).toBeInTheDocument();
   });
 });

--- a/tests/pages/RestaurantDetails.test.tsx
+++ b/tests/pages/RestaurantDetails.test.tsx
@@ -348,3 +348,52 @@ describe('RestaurantDetails - back link origin', () => {
     expect(screen.getByRole('button', { name: /back to list/i })).toBeInTheDocument();
   });
 });
+
+describe('RestaurantDetails - falsy-zero guards', () => {
+  // Detects a bare "0" rendered as a direct text node — the failure mode of a
+  // falsy `0 && <JSX>` guard, where React prints the number instead of hiding it.
+  const hasBareZeroTextNode = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('*')).some((el) =>
+      Array.from(el.childNodes).some(
+        (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim() === '0',
+      ),
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(restaurantService.getRestaurantByIdWithLocations).mockResolvedValue({
+      id: 'test-restaurant-id',
+      name: 'Test Restaurant',
+      address: 'Test Address',
+      status: 'to-visit',
+      atmosphere: 'A relaxed, community-focused venue.',
+      visit_count: 0,
+      public_rating: 0,
+      public_rating_count: 0,
+      locations: [{
+        id: 'loc-1',
+        restaurant_id: 'test-restaurant-id',
+        location_name: 'Main Location',
+        full_address: '123 Test St',
+        latitude: 51.5,
+        longitude: -0.1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    vi.mocked(visitService.getLatestVisits).mockResolvedValue([]);
+    vi.mocked(visitService.getVisitCount).mockResolvedValue(0);
+  });
+
+  it('does not render a stray "0" when numeric fields are 0', async () => {
+    const { container } = render(<RestaurantDetails />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('A relaxed, community-focused venue.')).toBeInTheDocument();
+    });
+
+    expect(hasBareZeroTextNode(container)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Some restaurant cards and the full details page showed a stray `0` — under **Atmosphere** on the details page and under the address on the "Where next?" cards.

## Cause

Classic React short-circuit gotcha. A guard like:

```jsx
{visit_count && visit_count > 1 && (...)}
```

short-circuits at `0` when `visit_count` is `0`. Unlike `false`/`null`/`undefined`, React renders the number `0` as visible text.

## Fix

Coerce the leading numeric operand to a boolean with `!!` so a falsy `0` renders nothing:

```jsx
{!!visit_count && visit_count > 1 && (...)}
```

- 3 `visit_count` guards (the reported bug): `PlaceCard.tsx`, `RestaurantDetails.tsx` (single- and multi-location layouts)
- 6 sibling guards hardened against the identical latent bug: `public_rating`, `public_rating_count`, `personal_rating`

## Testing

- `npm run lint` — 0 errors (pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
