### PR TITLE
Ignore .claude/worktrees/ (reviewer isolation worktrees)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ db_backup/
 # Claude Code runtime state (scheduled task locks, etc.)
 .claude/scheduled_tasks.lock
 
+# Throwaway git worktrees created by reviewer agents spawned with isolation: "worktree"
+.claude/worktrees/
+
 # Per-clone review system override (enables dogfooding without changing committed default)
 .claude/project-config.local.json
 


### PR DESCRIPTION
Adds `.claude/worktrees/` to `.gitignore`, under the existing "Claude Code runtime state" section.

Reviewer agents spawned with `isolation: "worktree"` (introduced in the read-only-reviewers rollout, #61) create throwaway git worktrees. They're auto-removed when unchanged, but ignoring the directory guarantees a stray one can never be accidentally committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)